### PR TITLE
Fix typos in README.md

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -450,7 +450,7 @@ zapier logs --type=http --detailed --limit=1
 # └─────────────────────┴────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-You can see from the detailed log that the request included our auth header. The value appears as `:censored:6:b1af149262:`, which is intentional. Zapier does not log authentincation credentials in plain text.
+You can see from the detailed log that the request included our auth header. The value appears as `:censored:6:b1af149262:`, which is intentional. Zapier does not log authentication credentials in plain text.
 
 With that, we've successfully added authentication to our app!
 
@@ -1240,7 +1240,7 @@ These work much like normal environment variables - for example:
 CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
 ```
 
-Or, `export` them explictly and place them into the environment:
+Or, `export` them explicitly and place them into the environment:
 
 ```bash
 export CLIENT_ID=1234

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ zapier logs --type=http --detailed --limit=1
 # └─────────────────────┴────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-You can see from the detailed log that the request included our auth header. The value appears as `:censored:6:b1af149262:`, which is intentional. Zapier does not log authentincation credentials in plain text.
+You can see from the detailed log that the request included our auth header. The value appears as `:censored:6:b1af149262:`, which is intentional. Zapier does not log authentication credentials in plain text.
 
 With that, we've successfully added authentication to our app!
 
@@ -1865,7 +1865,7 @@ These work much like normal environment variables - for example:
 CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
 ```
 
-Or, `export` them explictly and place them into the environment:
+Or, `export` them explicitly and place them into the environment:
 
 ```bash
 export CLIENT_ID=1234

--- a/docs/index.html
+++ b/docs/index.html
@@ -1026,7 +1026,7 @@ describe(<span class="hljs-string">&apos;My App&apos;</span>, () =&gt; {
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You can see from the detailed log that the request included our auth header. The value appears as <code>:censored:6:b1af149262:</code>, which is intentional. Zapier does not log authentincation credentials in plain text.</p><p>With that, we&apos;ve successfully added authentication to our app!</p>
+      <p>You can see from the detailed log that the request included our auth header. The value appears as <code>:censored:6:b1af149262:</code>, which is intentional. Zapier does not log authentication credentials in plain text.</p><p>With that, we&apos;ve successfully added authentication to our app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3124,7 +3124,7 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Or, <code>export</code> them explictly and place them into the environment:</p>
+      <p>Or, <code>export</code> them explicitly and place them into the environment:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-built_in">export</span> CLIENT_ID=1234


### PR DESCRIPTION
Just found some typos and fixed it.

~I don't know what software is used to generate the `README.md` from `README-source.md`, so I did it manually 😅~

Edit: Regenerated the documents using `npm docs`, should take a look at `package.json` first 😓 

