### PR TITLE
Log message that deploy key is being added to the environment

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const constants = require('../constants');
 const utils = require('../utils');
 
 const test = (context) => {
@@ -13,6 +14,7 @@ const test = (context) => {
 
   return utils.readCredentials(undefined, false)
     .then((credentials) => {
+      context.line('Adding ' + constants.AUTH_LOCATION + ' to environment as ZAPIER_DEPLOY_KEY...');
       extraEnv.ZAPIER_DEPLOY_KEY = credentials.deployKey;
     })
     .then(() => {


### PR DESCRIPTION
This is in conjunction with https://github.com/zapier/zapier-platform-core/pull/19. That solution depends on the `ZAPIER_DEPLOY_KEY` environment variable being set. Turns out we do already set it if you use `zapier test`, so this message combined with the error raised for a missing variable in that PR will hopefully be enough to inform devs that if they use regular `npm test` or the like, they will need to manually export that variable.