### PR TITLE
Use BASE_ENDPOINT instead of hard coding zapier.com in validation text

### DIFF
--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -11,7 +11,7 @@ const convert = (context, appid, location) => {
 
   appid = Number(appid);
   if (!appid) {
-    const message = 'You must provide an appid - get that from https://zapier.com/developer/builder/ (check the URL).';
+    const message = `You must provide an appid - get that from ${constants.BASE_ENDPOINT}/developer/builder/ (check the URL).`;
     return Promise.reject(new Error(message));
   }
 
@@ -33,7 +33,7 @@ const convert = (context, appid, location) => {
     });
 };
 convert.argsSpec = [
-  {name: 'appid', required: true, help: 'Get the appid from https://zapier.com/developer/builder/ (check the URL)'},
+  {name: 'appid', required: true, help: `Get the appid from ${constants.BASE_ENDPOINT}/developer/builder/ (check the URL)`},
   {name: 'location', required: true, help: 'Relative to your current path - IE: `.` for current directory'},
 ];
 convert.help = 'Converts a Zapier Platform app to a CLI app, stubs only.';

--- a/src/commands/invite.js
+++ b/src/commands/invite.js
@@ -1,5 +1,6 @@
 const utils = require('../utils');
 
+const constants = require('../constants');
 const makeAccess = require('./_access');
 
 const invite = makeAccess('invite', 'invitee');
@@ -29,7 +30,7 @@ $ zapier invite
 # 
 # Don't want to send individual invite emails? Use this public link and share with anyone on the web:
 # 
-#   https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/
+#   ${constants.BASE_ENDPOINT}/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/
 
 $ zapier invite user@example.com
 # Preparing to add invitee user@example.com to your app "Example".

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -21,7 +21,7 @@ const push = (context) => {
   return createIfNeeded(context)
     .then(() => utils.buildAndUploadDir())
     .then(() => {
-      context.line('\nBuild and upload complete! You should see it in your Zapier editor at https://zapier.com/app/editor now!');
+      context.line(`\nBuild and upload complete! You should see it in your Zapier editor at ${constants.BASE_ENDPOINT}/app/editor now!`);
     });
 };
 push.argsSpec = [];


### PR DESCRIPTION
Fixes #21 in the CLI - I did not make this change in the docs.