### PR TITLE
Fix typos in source, add links to Windows nvm alternatives

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -330,7 +330,7 @@ Probably the most "powerful" mechanism for authentication - it gives you the abi
 
 ### OAuth2
 
-Zapier's OAuth2 implementation is based on the the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
+Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-oauth2 for a working example app for oauth2.
 
@@ -816,7 +816,7 @@ z.request({
 Dehydration, and it's counterpart Hydration, is a tool that can lazily load data that might be otherwise expensive to retrieve aggressively.
 
 * **Dehydration** - think of this as "make a pointer", you control the creation of pointers with `z.dehydrate(func, inputData)`
-* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the the scenes
+* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the scenes
 
 > This is very common when [Stashing Files](#stashing-files) - but that isn't their only use!
 

--- a/README-source.md
+++ b/README-source.md
@@ -27,7 +27,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 ### What is an App?
 
 A CLI App is an implementation of your app's API. You build a Node.js application
-that exports a sinlge object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
+that exports a single object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.
 
@@ -39,7 +39,7 @@ map to the end user experience:
  * [Triggers](#triggerssearchescreates), which read data *from* your API. These have their own section in the Zap Editor.
  * [Creates](#triggerssearchescreates), which send data *to* your API to create new records. These are listed under "Actions" in the Zap Editor.
  * [Searches](#triggerssearchescreates), which find specific records *in* your system. These are also listed under "Actions" in the Zap Editor.
- * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.
+ * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. These are automatically extracted into Triggers, Searches, and Creates.
 
 ### How does the CLI Platform Work
 
@@ -468,7 +468,7 @@ Sometimes, API endpoints require clients to specify a parent object in order to 
 
 Our solution is to present users a dropdown that is populated by making a live API call to fetch a list of parent objects. We call these special dropdowns "dynamic dropdowns."
 
-To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-seperated concatination of a trigger's key, the field to use for the value, and the field to use for the label.
+To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-separated concatenation of a trigger's key, the field to use for the value, and the field to use for the label.
 
 ```javascript
 [insert-file:./snippets/dynamic-dropdowns.js]
@@ -482,7 +482,7 @@ In the UI, users will see something like this:
 
 ### Search-Powered Fields
 
-For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-seperated concatination of a search's key and the field to use for the value.
+For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-separated concatenation of a search's key and the field to use for the value.
 
 ```javascript
 [insert-file:./snippets/search-field.js]

--- a/README-source.md
+++ b/README-source.md
@@ -58,7 +58,7 @@ All Zapier CLI apps are run using Node.js `LAMBDA_VERSION`.
 
 You can develop using any version of Node you'd like, but your code has to run on Node `LAMBDA_VERSION`. You can accomplish this by developing on your preferred version and then transpiling with [Babel](https://babeljs.io/) (or similar).
 
-To ensure stability for our users, we also require that you run your tests on `LAMBDA_VERSION` as well. If you don't have it available, we recommend using either [nvm](https://github.com/creationix/nvm#installation) or [n](https://github.com/tj/n#installation) to install `LAMBDA_VERSION` and run the tests locally.
+To ensure stability for our users, we also require that you run your tests on `LAMBDA_VERSION` as well. If you don't have it available, we recommend using either [nvm](https://github.com/creationix/nvm#installation) or [n](https://github.com/tj/n#installation) to install `LAMBDA_VERSION` and run the tests locally. On Windows you can use [nvm-windows](https://github.com/coreybutler/nvm-windows#installation--upgrades) or [nodist](https://github.com/marcelklehr/nodist#installation).
 
 For NVM on Mac (via [homebrew](http://brew.sh/)):
 

--- a/README-source.md
+++ b/README-source.md
@@ -36,7 +36,7 @@ map to the end user experience:
 
  * [Authentication](#authentication), (usually) which lets us know what credentials to ask users
    for. This is used during the "Connect Accounts" section of the Zap Editor.
- * [Triggers](#triggerssearchescreates), which read data *from* your API. These have theior own section in the Zap Editor.
+ * [Triggers](#triggerssearchescreates), which read data *from* your API. These have their own section in the Zap Editor.
  * [Creates](#triggerssearchescreates), which send data *to* your API to create new records. These are listed under "Actions" in the Zap Editor.
  * [Searches](#triggerssearchescreates), which find specific records *in* your system. These are also listed under "Actions" in the Zap Editor.
  * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.
@@ -50,7 +50,7 @@ and returns the relevant data, which gets fed back into Zapier.
 
 ### CLI vs the Web Builder Platform
 
-From a user perspective, both the CLI and the existing web builder platform offer the same experience. The biggest difference is how they're developed. The CLI takes a much more code-first approach, allowing you develop your Zapier app just like you would any other programming project. The web builder, on the other hand, is much better for folks who want to make an app with minimal coding involved. Both will continue to coexist, so pick whichever fits your needs best!
+From a user perspective, both the CLI and the existing web builder platform offer the same experience. The biggest difference is how they're developed. The CLI takes a much more code-first approach, allowing you to develop your Zapier app just like you would any other programming project. The web builder, on the other hand, is much better for folks who want to make an app with minimal coding involved. Both will continue to coexist, so pick whichever fits your needs best!
 
 ### Requirements
 
@@ -302,7 +302,7 @@ Useful if your app requires two pieces of information to authentication: `userna
 
 ### Custom
 
-This is what most "API Key" driven apps should default to using. You'll likely provide some some custom `beforeRequest` middleware or a `requestTemplate` to complete the authentication by adding/computing needed headers.
+This is what most "API Key" driven apps should default to using. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` to complete the authentication by adding/computing needed headers.
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-custom-auth for a working example app for custom auth.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 ### What is an App?
 
 A CLI App is an implementation of your app's API. You build a Node.js application
-that exports a single object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
+that exports a sinlge object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.
 
@@ -118,7 +118,7 @@ map to the end user experience:
  * [Triggers](#triggerssearchescreates), which read data *from* your API. These have their own section in the Zap Editor.
  * [Creates](#triggerssearchescreates), which send data *to* your API to create new records. These are listed under "Actions" in the Zap Editor.
  * [Searches](#triggerssearchescreates), which find specific records *in* your system. These are also listed under "Actions" in the Zap Editor.
- * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. These are automatically extracted into Triggers, Searches, and Creates.
+ * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.
 
 ### How does the CLI Platform Work
 
@@ -137,7 +137,7 @@ All Zapier CLI apps are run using Node.js `v4.3.2`.
 
 You can develop using any version of Node you'd like, but your code has to run on Node `v4.3.2`. You can accomplish this by developing on your preferred version and then transpiling with [Babel](https://babeljs.io/) (or similar).
 
-To ensure stability for our users, we also require that you run your tests on `v4.3.2` as well. If you don't have it available, we recommend using either [nvm](https://github.com/creationix/nvm#installation) or [n](https://github.com/tj/n#installation) to install `v4.3.2` and run the tests locally.
+To ensure stability for our users, we also require that you run your tests on `v4.3.2` as well. If you don't have it available, we recommend using either [nvm](https://github.com/creationix/nvm#installation) or [n](https://github.com/tj/n#installation) to install `v4.3.2` and run the tests locally. On Windows you can use [nvm-windows](https://github.com/coreybutler/nvm-windows#installation--upgrades) or [nodist](https://github.com/marcelklehr/nodist#installation).
 
 For NVM on Mac (via [homebrew](http://brew.sh/)):
 
@@ -562,7 +562,7 @@ const App = {
 
 ### OAuth2
 
-Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
+Zapier's OAuth2 implementation is based on the the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-oauth2 for a working example app for oauth2.
 
@@ -889,7 +889,7 @@ Sometimes, API endpoints require clients to specify a parent object in order to 
 
 Our solution is to present users a dropdown that is populated by making a live API call to fetch a list of parent objects. We call these special dropdowns "dynamic dropdowns."
 
-To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-separated concatenation of a trigger's key, the field to use for the value, and the field to use for the label.
+To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-seperated concatination of a trigger's key, the field to use for the value, and the field to use for the label.
 
 ```javascript
 const App = {
@@ -931,7 +931,7 @@ In the UI, users will see something like this:
 
 ### Search-Powered Fields
 
-For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-separated concatenation of a search's key and the field to use for the value.
+For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-seperated concatination of a search's key and the field to use for the value.
 
 ```javascript
 const App = {
@@ -1426,7 +1426,7 @@ z.request({
 Dehydration, and it's counterpart Hydration, is a tool that can lazily load data that might be otherwise expensive to retrieve aggressively.
 
 * **Dehydration** - think of this as "make a pointer", you control the creation of pointers with `z.dehydrate(func, inputData)`
-* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the scenes
+* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the the scenes
 
 > This is very common when [Stashing Files](#stashing-files) - but that isn't their only use!
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 ### What is an App?
 
 A CLI App is an implementation of your app's API. You build a Node.js application
-that exports a sinlge object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
+that exports a single object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.
 
@@ -120,7 +120,7 @@ map to the end user experience:
  * [Triggers](#triggerssearchescreates), which read data *from* your API. These have their own section in the Zap Editor.
  * [Creates](#triggerssearchescreates), which send data *to* your API to create new records. These are listed under "Actions" in the Zap Editor.
  * [Searches](#triggerssearchescreates), which find specific records *in* your system. These are also listed under "Actions" in the Zap Editor.
- * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.
+ * [Resources](#resources), which define an object type in your API (say a contact) and the operations available to perform on it. These are automatically extracted into Triggers, Searches, and Creates.
 
 ### How does the CLI Platform Work
 
@@ -891,7 +891,7 @@ Sometimes, API endpoints require clients to specify a parent object in order to 
 
 Our solution is to present users a dropdown that is populated by making a live API call to fetch a list of parent objects. We call these special dropdowns "dynamic dropdowns."
 
-To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-seperated concatination of a trigger's key, the field to use for the value, and the field to use for the label.
+To define one, you can provide the `dynamic` property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-separated concatenation of a trigger's key, the field to use for the value, and the field to use for the label.
 
 ```javascript
 const App = {
@@ -933,7 +933,7 @@ In the UI, users will see something like this:
 
 ### Search-Powered Fields
 
-For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-seperated concatination of a search's key and the field to use for the value.
+For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the `search` property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-separated concatenation of a search's key and the field to use for the value.
 
 ```javascript
 const App = {

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ const App = {
 
 ### OAuth2
 
-Zapier's OAuth2 implementation is based on the the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
+Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](http://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-oauth2 for a working example app for oauth2.
 
@@ -1426,7 +1426,7 @@ z.request({
 Dehydration, and it's counterpart Hydration, is a tool that can lazily load data that might be otherwise expensive to retrieve aggressively.
 
 * **Dehydration** - think of this as "make a pointer", you control the creation of pointers with `z.dehydrate(func, inputData)`
-* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the the scenes
+* **Hydration** - think of this as an automatic step that "consumes a pointer" and "returns some data", Zapier does this automatically behind the scenes
 
 > This is very common when [Stashing Files](#stashing-files) - but that isn't their only use!
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- GENERATED! ONLY EDIT `README-source.md` -->
+
 <h1 align="center">
   <a href="https://zapier.com"><img src="https://cdn.rawgit.com/zapier/zapier-platform-cli/master/goodies/zapier-logomark.png" alt="Zapier" width="200"></a>
   <br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -494,7 +494,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>A CLI App is an implementation of your app&apos;s API. You build a Node.js application
-that exports a sinlge object (<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema">JSON Schema</a>) and upload it to Zapier.
+that exports a single object (<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema">JSON Schema</a>) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.</p><p>For those not familiar with Zapier terminology, here is how concepts in the CLI
 map to the end user experience:</p><ul>
@@ -503,7 +503,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 <li><a href="#triggerssearchescreates">Triggers</a>, which read data <em>from</em> your API. These have their own section in the Zap Editor.</li>
 <li><a href="#triggerssearchescreates">Creates</a>, which send data <em>to</em> your API to create new records. These are listed under &quot;Actions&quot; in the Zap Editor.</li>
 <li><a href="#triggerssearchescreates">Searches</a>, which find specific records <em>in</em> your system. These are also listed under &quot;Actions&quot; in the Zap Editor.</li>
-<li><a href="#resources">Resources</a>, which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.</li>
+<li><a href="#resources">Resources</a>, which define an object type in your API (say a contact) and the operations available to perform on it. These are automatically extracted into Triggers, Searches, and Creates.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1633,7 +1633,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Sometimes, API endpoints require clients to specify a parent object in order to create or access the child resources. Imagine having to specify a company id in order to get a list of employees for that company. Since people don&apos;t speak in auto-incremented ID&apos;s, it is necessary that Zapier offer a simple way to select that parent using human readable handles.</p><p>Our solution is to present users a dropdown that is populated by making a live API call to fetch a list of parent objects. We call these special dropdowns &quot;dynamic dropdowns.&quot;</p><p>To define one, you can provide the <code>dynamic</code> property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-seperated concatination of a trigger&apos;s key, the field to use for the value, and the field to use for the label.</p>
+      <p>Sometimes, API endpoints require clients to specify a parent object in order to create or access the child resources. Imagine having to specify a company id in order to get a list of employees for that company. Since people don&apos;t speak in auto-incremented ID&apos;s, it is necessary that Zapier offer a simple way to select that parent using human readable handles.</p><p>Our solution is to present users a dropdown that is populated by making a live API call to fetch a list of parent objects. We call these special dropdowns &quot;dynamic dropdowns.&quot;</p><p>To define one, you can provide the <code>dynamic</code> property on your field to specify the trigger that should be used to populate the options for the dropdown. The value for the property is a dot-separated concatenation of a trigger&apos;s key, the field to use for the value, and the field to use for the label.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> App = {
@@ -1690,7 +1690,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the <code>search</code> property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-seperated concatination of a search&apos;s key and the field to use for the value.</p>
+      <p>For fields that take id of another object to create a relationship between the two (EG: a project id for a ticket), you can specify the <code>search</code> property on the field to indicate that Zapier needs to prompt the user to setup a Search step to populate the value for this field. Similar to dynamic dropdowns, the value for this property is a dot-separated concatenation of a search&apos;s key and the field to use for the value.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> App = {

--- a/docs/index.html
+++ b/docs/index.html
@@ -500,7 +500,7 @@ what options to present end users in the Zap Editor.</p><p>For those not familia
 map to the end user experience:</p><ul>
 <li><a href="#authentication">Authentication</a>, (usually) which lets us know what credentials to ask users
 for. This is used during the &quot;Connect Accounts&quot; section of the Zap Editor.</li>
-<li><a href="#triggerssearchescreates">Triggers</a>, which read data <em>from</em> your API. These have theior own section in the Zap Editor.</li>
+<li><a href="#triggerssearchescreates">Triggers</a>, which read data <em>from</em> your API. These have their own section in the Zap Editor.</li>
 <li><a href="#triggerssearchescreates">Creates</a>, which send data <em>to</em> your API to create new records. These are listed under &quot;Actions&quot; in the Zap Editor.</li>
 <li><a href="#triggerssearchescreates">Searches</a>, which find specific records <em>in</em> your system. These are also listed under &quot;Actions&quot; in the Zap Editor.</li>
 <li><a href="#resources">Resources</a>, which define an object type in your API (say a contact) and the operations available to perform on it. Tehse are automatically extracted into Triggers, Searches, and Creates.</li>
@@ -543,7 +543,7 @@ and returns the relevant data, which gets fed back into Zapier.</p>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>From a user perspective, both the CLI and the existing web builder platform offer the same experience. The biggest difference is how they&apos;re developed. The CLI takes a much more code-first approach, allowing you develop your Zapier app just like you would any other programming project. The web builder, on the other hand, is much better for folks who want to make an app with minimal coding involved. Both will continue to coexist, so pick whichever fits your needs best!</p>
+      <p>From a user perspective, both the CLI and the existing web builder platform offer the same experience. The biggest difference is how they&apos;re developed. The CLI takes a much more code-first approach, allowing you to develop your Zapier app just like you would any other programming project. The web builder, on the other hand, is much better for folks who want to make an app with minimal coding involved. Both will continue to coexist, so pick whichever fits your needs best!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -561,7 +561,7 @@ and returns the relevant data, which gets fed back into Zapier.</p>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>All Zapier CLI apps are run using Node.js <code>v4.3.2</code>.</p><p>You can develop using any version of Node you&apos;d like, but your code has to run on Node <code>v4.3.2</code>. You can accomplish this by developing on your preferred version and then transpiling with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we also require that you run your tests on <code>v4.3.2</code> as well. If you don&apos;t have it available, we recommend using either <a href="https://github.com/creationix/nvm#installation">nvm</a> or <a href="https://github.com/tj/n#installation">n</a> to install <code>v4.3.2</code> and run the tests locally.</p><p>For NVM on Mac (via <a href="http://brew.sh/">homebrew</a>):</p>
+      <p>All Zapier CLI apps are run using Node.js <code>v4.3.2</code>.</p><p>You can develop using any version of Node you&apos;d like, but your code has to run on Node <code>v4.3.2</code>. You can accomplish this by developing on your preferred version and then transpiling with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we also require that you run your tests on <code>v4.3.2</code> as well. If you don&apos;t have it available, we recommend using either <a href="https://github.com/creationix/nvm#installation">nvm</a> or <a href="https://github.com/tj/n#installation">n</a> to install <code>v4.3.2</code> and run the tests locally. On Windows you can use <a href="https://github.com/coreybutler/nvm-windows#installation--upgrades">nvm-windows</a> or <a href="https://github.com/marcelklehr/nodist#installation">nodist</a>.</p><p>For NVM on Mac (via <a href="http://brew.sh/">homebrew</a>):</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">brew install nvm
@@ -1075,7 +1075,7 @@ zapier convert 1234 .
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This is what most &quot;API Key&quot; driven apps should default to using. You&apos;ll likely provide some some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> to complete the authentication by adding/computing needed headers.</p><blockquote>
+      <p>This is what most &quot;API Key&quot; driven apps should default to using. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> to complete the authentication by adding/computing needed headers.</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-custom-auth">https://github.com/zapier/zapier-platform-example-app-custom-auth</a> for a working example app for custom auth.</p>
 </blockquote>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1237,7 +1237,7 @@ zapier convert 1234 .
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Zapier&apos;s OAuth2 implementation is based on the the <code>authorization_code</code> flow, similar to <a href="http://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
+      <p>Zapier&apos;s OAuth2 implementation is based on the <code>authorization_code</code> flow, similar to <a href="http://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-oauth2">https://github.com/zapier/zapier-platform-example-app-oauth2</a> for a working example app for oauth2.</p>
 </blockquote><p>It looks like this:</p><ol>
 <li>Zapier sends the user to the authorization URL defined by your App</li>
@@ -2520,7 +2520,7 @@ zapier env 1.0.0
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Dehydration, and it&apos;s counterpart Hydration, is a tool that can lazily load data that might be otherwise expensive to retrieve aggressively.</p><ul>
 <li><strong>Dehydration</strong> - think of this as &quot;make a pointer&quot;, you control the creation of pointers with <code>z.dehydrate(func, inputData)</code></li>
-<li><strong>Hydration</strong> - think of this as an automatic step that &quot;consumes a pointer&quot; and &quot;returns some data&quot;, Zapier does this automatically behind the the scenes</li>
+<li><strong>Hydration</strong> - think of this as an automatic step that &quot;consumes a pointer&quot; and &quot;returns some data&quot;, Zapier does this automatically behind the scenes</li>
 </ul><blockquote>
 <p>This is very common when <a href="#stashing-files">Stashing Files</a> - but that isn&apos;t their only use!</p>
 </blockquote><p>The interface <code>z.dehydrate(func, inputData)</code> has two required arguments:</p><ul>

--- a/src/bin/docs.js
+++ b/src/bin/docs.js
@@ -75,7 +75,8 @@ const buildReadme = () => {
 
   const lines = fs.readFileSync(readmeSrc, 'utf8').split('\n');
   const newLines = lines.map(maybeInsertSnippet).map(fillLambdaVersion).join('\n');
-  fs.writeFileSync(readmeDst, toc.insert(newLines));
+  const tocInstered = toc.insert(newLines);
+  fs.writeFileSync(readmeDst, '<!-- GENERATED! ONLY EDIT `README-source.md` -->\n\n' + tocInstered);
 };
 
 buildReadme();


### PR DESCRIPTION
It looks like we fixed some typos in `README.md` instead of `README-source.md`. Took care of that and added a comment generated in `README.md` to prevent this from happening again (hopefully).

Also added links to the Windows alternatives for `nvm` and `n`.