### PR TITLE
Fix missing MIN_NODE_VERSION

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -4,7 +4,7 @@ require('babel-polyfill');
 const _ = require('lodash');
 const colors = require('colors/safe');
 
-const {DEBUG, MIN_NODE_VERSION, PLATFORM_PACKAGE} = require('./constants');
+const {DEBUG, PLATFORM_PACKAGE} = require('./constants');
 const commands = require('./commands');
 const utils = require('./utils');
 
@@ -17,7 +17,7 @@ module.exports = (argv) => {
 
   if (!utils.isValidNodeVersion()) {
     console.error(colors.red(
-      `Requires node version >= ${MIN_NODE_VERSION.major}.${MIN_NODE_VERSION.minor}.${MIN_NODE_VERSION.patch}, found ${process.versions.node}. Please upgrade node.`
+      `Requires node version >= ${utils.readNvmVersion()}, found ${process.versions.node}. Please upgrade node.`
     ));
     process.exit(1);
   }

--- a/src/tests/utils/misc.js
+++ b/src/tests/utils/misc.js
@@ -3,6 +3,14 @@ const misc = require('../../utils/misc');
 
 describe('misc utils', () => {
 
+  describe('readNvmVersion', () => {
+
+    it('should return .nvmrc verson (without leading `v`)', () => {
+      misc.readNvmVersion().should.equal('4.3.2');
+    });
+
+  });
+
   describe('isValidNodeVersion', () => {
 
     it('should return true when valid node version', () => {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -65,9 +65,14 @@ const parseVersions = (versionString) => (
   versionString.split('.').map(s => parseInt(s, 10))
 );
 
-const isValidNodeVersion = () => {
+const readNvmVersion = () => {
   const nvmrc = path.resolve(__dirname, '../../.nvmrc');
   const nvmVersion = fse.readFileSync(nvmrc, 'utf8').substr(1); // strip of leading 'v'
+  return nvmVersion;
+};
+
+const isValidNodeVersion = () => {
+  const nvmVersion = readNvmVersion();
 
   const [nvmMajor, nvmMinor, nvmPatch] = parseVersions(nvmVersion);
   const [major, minor, patch] = parseVersions(process.versions.node);
@@ -151,6 +156,7 @@ module.exports = {
   camelCase,
   snakeCase,
   runCommand,
+  readNvmVersion,
   isValidNodeVersion,
   isValidAppInstall,
   npmInstall,


### PR DESCRIPTION
Fixes by splitting off part of `isValidNodeVersion` into `readNvmVersion` to use instead (test for new fn added).

```
C:\Users\fokkezb\git\ZapierTest>zapier test
undefined
C:\Program Files (x86)\Nodist\bin\node_modules\zapier-platform-cli\lib\entry.js:28
    console.error(colors.red('Requires node version >= ' + MIN_NODE_VERSION.major + '.' + MIN_NODE_VERSION.minor + '.' + MIN_NODE_VERSION.patch + ', found ' + process.versions.node + '. Please upgrade node.'));
                                                                           ^

TypeError: Cannot read property 'major' of undefined
    at module.exports (C:\Program Files (x86)\Nodist\bin\node_modules\zapier-platform-cli\lib\entry.js:28:76)
    at Object.<anonymous> (C:\Program Files (x86)\Nodist\bin\node_modules\zapier-platform-cli\zapier.js:3:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:134:18)
    at node.js:962:3
```