### PR TITLE
Parse outputFields for `zapier convert`

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -139,4 +139,32 @@ describe('convert render functions', () => {
       done();
     });
   });
+
+  describe('render sample', () => {
+    it('should render sample output fields', () => {
+      const v2Def = {
+        sample_result_fields: [
+          { type: 'float', key: 'bounds__northeast__lat' },
+          { type: 'float', key: 'bounds__northeast__lng' },
+          { type: 'float', key: 'bounds__southwest__lat' },
+          { type: 'float', key: 'bounds__southwest__lng' },
+          { type: 'unicode', key: 'copyrights', label: 'Copyright' },
+          { type: 'unicode', key: 'legs[]duration__text', important: true, label: 'Legs Duration' },
+        ]
+      };
+
+      const string = '{' + convert.renderSample(v2Def) + '}';
+      const fields = s2js(string);
+      fields.should.eql({
+        outputFields: [
+          { type: 'number', key: 'bounds__northeast__lat' },
+          { type: 'number', key: 'bounds__northeast__lng' },
+          { type: 'number', key: 'bounds__southwest__lat' },
+          { type: 'number', key: 'bounds__southwest__lng' },
+          { type: 'string', key: 'copyrights', label: 'Copyright' },
+          { type: 'string', key: 'legs[]duration__text', label: 'Legs Duration' },
+        ]
+      });
+    });
+  });
 });

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -102,7 +102,7 @@ const renderSampleField = (def) => {
 const renderSample = (definition) => {
   const fields = _.map(definition.sample_result_fields, renderSampleField);
 
-  if (!fields || fields.length === 0) {
+  if (!fields.length) {
     return '';
   }
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -83,20 +83,32 @@ ${props.join(',\n')}
 };
 
 const renderSampleField = (def) => {
-  const type = typesMap[def.type];
+  const type = typesMap[def.type] || 'string';
 
-  return `      ${def.key}: {
+  if (def.label) {
+    return `      {
+        key: ${quote(def.key)},
         type: ${quote(type)},
         label: ${quote(def.label)}
+      }`;
+  }
+
+  return `      {
+        key: ${quote(def.key)},
+        type: ${quote(type)}
       }`;
 };
 
 const renderSample = (definition) => {
   const fields = _.map(definition.sample_result_fields, renderSampleField);
 
-  return `    sample: {
+  if (!fields || fields.length === 0) {
+    return '';
+  }
+
+  return `    outputFields: [
 ${fields.join(',\n')}
-    }`;
+    ]`;
 };
 
 const renderBasicAuth = (definition) => {


### PR DESCRIPTION
Fixes #23

To really create a `sample`, we'd need to get info in the v2 definition dump that we currently don't have.