### PR TITLE
Improves validate-templates and zapier test commands

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1138,6 +1138,7 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 </blockquote><p>  <strong>Usage:</strong> <code>zapier test</code></p><p>  This command is effectively the same as <code>npm test</code>, except we wire in some custom tests to validate your app. We recommend using mocha as your testing framework.</p><p><strong>Arguments</strong></p><ul>
 <li><code>--quiet</code> -- <em>optional</em>, do not print zapier detailed logs to standard out</li>
 <li><code>--very-quiet</code> -- <em>optional</em>, do not print zapier summary or detail logs to standard out</li>
+<li><code>--timeout=value</code> -- <em>optional</em>, add a default timeout to mocha, in milliseconds</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -790,6 +790,7 @@ $ zapier scaffold resource "Tag" --entry=index.js --dest=resources/tag
 
 * `--quiet` -- _optional_, do not print zapier detailed logs to standard out
 * `--very-quiet` -- _optional_, do not print zapier summary or detail logs to standard out
+* `--timeout=value` -- _optional_, add a default timeout to mocha, in milliseconds
 
 ```bash
 $ zapier test

--- a/scripts/validate-app-templates.js
+++ b/scripts/validate-app-templates.js
@@ -13,7 +13,7 @@ const appTemplates = require('../lib/app-templates');
 const validateAppTemplate = (template, rootTmpDir) => {
   //const appDir = path.resolve(rootTmpDir, template);
   const zapierCmd = path.resolve(__dirname, '../zapier.js');
-  const extraCmd = (template === 'babel') ? ' && rm -rf lib && node_modules/babel-cli/bin/babel.js src --out-dir lib' : '';
+  const extraCmd = (template === 'babel') ? ' && npm run zapier-build' : '';
 
   const logFile = path.resolve(__dirname, '..', `${template}.log`);
   const logStream = fse.createWriteStream(logFile);

--- a/scripts/validate-app-templates.js
+++ b/scripts/validate-app-templates.js
@@ -13,6 +13,7 @@ const appTemplates = require('../lib/app-templates');
 const validateAppTemplate = (template, rootTmpDir) => {
   //const appDir = path.resolve(rootTmpDir, template);
   const zapierCmd = path.resolve(__dirname, '../zapier.js');
+  const extraCmd = (template === 'babel') ? ' && rm -rf lib && node_modules/babel-cli/bin/babel.js src --out-dir lib' : '';
 
   const logFile = path.resolve(__dirname, '..', `${template}.log`);
   const logStream = fse.createWriteStream(logFile);
@@ -21,7 +22,7 @@ const validateAppTemplate = (template, rootTmpDir) => {
   return fse.ensureFileAsync(logFile)
     .then(() => {
       return new Promise((resolve, reject) => {
-        const cmd = `${zapierCmd} init ${template} --template=${template} --debug && cd ${template} && npm install && ${zapierCmd} validate && export CLIENT_ID=1234 CLIENT_SECRET=asdf && ${zapierCmd} test`;
+        const cmd = `${zapierCmd} init ${template} --template=${template} --debug && cd ${template} && npm install ${extraCmd} && ${zapierCmd} validate && export CLIENT_ID=1234 CLIENT_SECRET=asdf && ${zapierCmd} test --timeout=5000`;
         const child = childProcess.exec(cmd, {cwd: rootTmpDir}, err => {
           if (err) {
             console.log('error starting child process:', err);

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -26,7 +26,14 @@ const test = (context) => {
     })
     .then(() => {
       const env = _.extend({}, process.env, extraEnv);
-      return utils.runCommand('npm', ['run', '--silent', 'test'], {stdio: 'inherit', env})
+      const commands = ['run', '--silent', 'test'];
+
+      if (global.argOpts.timeout) {
+        commands.push('--');
+        commands.push(`--timeout=${global.argOpts.timeout}`);
+      }
+
+      return utils.runCommand('npm', commands, {stdio: 'inherit', env})
         .then((stdout) => {
           if (stdout) {
             context.line(stdout);
@@ -38,7 +45,8 @@ test.argsSpec = [
 ];
 test.argOptsSpec = {
   quiet: {flag: true, help: 'do not print zapier detailed logs to standard out'},
-  'very-quiet': {flag: true, help: 'do not print zapier summary or detail logs to standard out'}
+  'very-quiet': {flag: true, help: 'do not print zapier summary or detail logs to standard out'},
+  timeout: {help: 'add a default timeout to mocha, in milliseconds'},
 };
 test.help = 'Tests your app via `npm test`.';
 test.example = 'zapier test';


### PR DESCRIPTION
- `zapier test` now supports a `--timeout=X` for X milliseconds added to mocha.
- `npm run validate-templates` now adds a timeout for mocha, and builds the babel example before testing.