### PR TITLE
hit server for style checks and display them

### DIFF
--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -50,7 +50,7 @@ const validate = (context) => {
         context.line('Your app is structurally invalid. Address concerns and run this command again.');
         process.exitCode = 1;
       } else {
-        context.line('This project looks good!');
+        context.line('This project is structurally sound!');
       }
     })
     .then(() => {
@@ -76,8 +76,8 @@ const validate = (context) => {
                 ['Description', 'description'],
                 ['Link', 'link']
               ], ifEmpty, true);
-              context.line('Errors will prevent deploys, warnings are things to improve on.\n');
               process.exitCode = 1;
+              context.line('Errors will prevent promotions, warnings are things to improve on.\n');
             } else {
               context.line('Your app looks great!\n');
             }
@@ -106,7 +106,7 @@ $ zapier validate
 #
 # No errors found during validation routine.
 #
-# This project looks good!
+# This project is structurally sound!
 
 $ zapier validate
 # Validating project locally.

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -5,7 +5,7 @@ const utils = require('../utils');
 
 
 const validate = (context) => {
-  context.line('Validating project locally.\n');
+  context.line('\nValidating project locally.');
   return Promise.resolve()
     .then(() => utils.localAppCommand({command: 'validate'}))
     .then((errors) => {
@@ -15,7 +15,7 @@ const validate = (context) => {
         error.docLinks = (error.docLinks || []).join('\n');
         return error;
       });
-      const ifEmpty = colors.grey('No errors found during validation routine.');
+      const ifEmpty = colors.grey('No structural errors found during validation routine.');
       utils.printData(newErrors, [
         ['Property', 'property'],
         ['Message', 'message'],
@@ -25,14 +25,56 @@ const validate = (context) => {
     })
     .then((errors) => {
       if (errors.length) {
-        context.line(`\nMake any changes to your project and rerun this command.`);
+        context.line('Your app is structurally invalid. Address concerns and run this command again.');
       } else {
-        context.line(`\nThis project looks good!`);
+        context.line('This project looks good!');
+      }
+    })
+    .then(() => {
+      if (global.argOpts['include-style']) {
+        utils.localAppCommand({ command: 'definition' })
+          .then((rawDefinition) => {
+            return utils.callAPI('/style-check', {
+              skipDeployKey: true,
+              method: 'POST',
+              body: rawDefinition
+            });
+          })
+          .then((styleResult) => {
+            // process errors
+            let res = [];
+            context.line('\nChecking app style.');
+            const ifEmpty = colors.grey('No style errors found during validation routine.');
+            for (const severity in styleResult) {
+              for (const type in styleResult[severity]) {
+                for (const method in styleResult[severity][type]) {
+                  res.push({
+                    category: severity,
+                    method: `${type}.${method}`,
+                    description: styleResult[severity][type][method].join('\n')
+                  });
+                }
+              }
+            }
+
+            if (res.length) {
+              utils.printData(res, [
+                ['Category', 'category'],
+                ['Method', 'method'],
+                ['Description', 'description'],
+              ], ifEmpty, true);
+              context.line('Errors will prevent deploys, warnings are things to improve on.\n');
+            } else {
+              context.line('Your app looks great!\n');
+            }
+          });
       }
     });
 };
 validate.argsSpec = [];
-validate.argOptsSpec = {};
+validate.argOptsSpec = {
+  'include-style': { flag: true, help: 'ping the Zapier server to do a style check' },
+};
 validate.help = 'Validates the current app.';
 validate.example = 'zapier validate';
 validate.docs = `\
@@ -47,21 +89,21 @@ ${utils.defaultArgOptsFragment()}
 ${'```'}bash
 $ zapier validate
 # Validating project locally.
-# 
+#
 # No errors found during validation routine.
-# 
+#
 # This project looks good!
 
 $ zapier validate
 # Validating project locally.
-# 
+#
 # ┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 # │ = 1 =                                                                                                      │
 # │     Property │ instance                                                                                    │
 # │     Message  │ requires property "platformVersion"                                                         │
 # │     Links    │ https://github.com/zapier/zapier-platform-schema/blob/v1.0.0/docs/build/schema.md#appschema │
 # └──────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
-# 
+#
 # Make any changes to your project and rerun this command.
 ${'```'}
 `;

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -48,6 +48,7 @@ const validate = (context) => {
     .then((errors) => {
       if (errors.length) {
         context.line('Your app is structurally invalid. Address concerns and run this command again.');
+        process.exitCode = 1;
       } else {
         context.line('This project looks good!');
       }
@@ -76,6 +77,7 @@ const validate = (context) => {
                 ['Link', 'link']
               ], ifEmpty, true);
               context.line('Errors will prevent deploys, warnings are things to improve on.\n');
+              process.exitCode = 1;
             } else {
               context.line('Your app looks great!\n');
             }

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -197,7 +197,7 @@ const formatStyles = {
 };
 
 const printData = (rows, columnDefs, ifEmptyMessage = '', useRowBasedTable = false) => {
-  const formatStyle = (global.argOpts || {}).format || (useRowBasedTable ? 'row-based' : DEFAULT_STYLE);
+  const formatStyle = (global.argOpts || {}).format || (useRowBasedTable ? 'row' : DEFAULT_STYLE);
   const formatter = formatStyles[formatStyle] || formatStyles[DEFAULT_STYLE];
   if (rows && !rows.length) {
     console.log(ifEmptyMessage);


### PR DESCRIPTION
The [server](https://github.com/zapier/zapier/pull/11566) half of this PR has to be deployed before this will work. 

Also, fixed a [small bug](https://zapier.slack.com/archives/C151BFEJ3/p1492215596637070) where the `useRowBasedTable` option for `printData` was accidentally ignored. 

I tweaked some spacing to make it more clear what boxes output ties too. All together, it looks like: 

```
zapier-steam [master] % zapier validate --include-style

Validating project locally.
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ = 1 =                                                                                                                        │
│     Property │ App.triggers.steam_level.operation                                                                            │
│     Message  │ is not any of </BasicPollingOperationSchema>,</BasicHookOperationSchema>                                      │
│     Links    │ https://github.com/zapier/zapier-platform-schema/blob/v0.9.8/docs/build/schema.md#basicpollingoperationschema │
│              │ https://github.com/zapier/zapier-platform-schema/blob/v0.9.8/docs/build/schema.md#basichookoperationschema    │
│                                                                                                                              │
│ = 2 =                                                                                                                        │
│     Property │ App.triggers.game.operation                                                                                   │
│     Message  │ is not any of </BasicPollingOperationSchema>,</BasicHookOperationSchema>                                      │
│     Links    │ https://github.com/zapier/zapier-platform-schema/blob/v0.9.8/docs/build/schema.md#basicpollingoperationschema │
│              │ https://github.com/zapier/zapier-platform-schema/blob/v0.9.8/docs/build/schema.md#basichookoperationschema    │
└──────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
Your app is structurally invalid. Address concerns and run this command again.

Checking app style.
┌─────────────────────────────────────────────────────────────────────┐
│ = 1 =                                                               │
│     Category    │ errors                                            │
│     Method      │ read.game                                         │
│     Description │ is missing `id` field in sample data.             │
│                                                                     │
│ = 2 =                                                               │
│     Category    │ errors                                            │
│     Method      │ read.game_played                                  │
│     Description │ is missing `id` field in sample data.             │
│                                                                     │
│ = 3 =                                                               │
│     Category    │ errors                                            │
│     Method      │ read.steam_level                                  │
│     Description │ is missing `id` field in sample data.             │
│                                                                     │
│ = 4 =                                                               │
│     Category    │ warnings                                          │
│     Method      │ read.game                                         │
│     Description │ has 56 characters (which is over the limit of 50) │
└─────────────────┴───────────────────────────────────────────────────┘
Errors will prevent deploys, warnings are things to improve on.

zapier-steam [master] %
```