### PR TITLE
RFC: Check if bundle.authData exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,9 @@ const authentication = {
 };
 
 const addBearerHeader = (request, z, bundle) => {
-  request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+  if (bundle.authData && bundle.authData.access_token) {
+    request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+  }
   return request;
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1312,7 +1312,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 };
 
 <span class="hljs-keyword">const</span> addBearerHeader = <span class="hljs-function">(<span class="hljs-params">request, z, bundle</span>) =&gt;</span> {
-  request.headers.Authorization = <span class="hljs-string">`Bearer <span class="hljs-subst">${bundle.authData.access_token}</span>`</span>;
+  <span class="hljs-keyword">if</span> (bundle.authData &amp;&amp; bundle.authData.access_token) {
+    request.headers.Authorization = <span class="hljs-string">`Bearer <span class="hljs-subst">${bundle.authData.access_token}</span>`</span>;
+  }
   <span class="hljs-keyword">return</span> request;
 };
 

--- a/snippets/oauth2.js
+++ b/snippets/oauth2.js
@@ -36,7 +36,9 @@ const authentication = {
 };
 
 const addBearerHeader = (request, z, bundle) => {
-  request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+  if (bundle.authData && bundle.authData.access_token) {
+    request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+  }
   return request;
 };
 


### PR DESCRIPTION
Without this change, `getAccessToken()` will fail with:

```
  1) oauth2 app can fetch an access token:
     Cannot read property 'access_token' of undefined
What happened:
  Starting POST request to http://zapier.webscript.io/platform-example-app/access-token
  Cannot read property 'access_token' of undefined
  TypeError: Cannot read property 'access_token' of undefined
      at includeBearerToken (/Users/fokkezb/git/zapier-platform-example-app-oauth2/index.js:11:22)
      at Object.<anonymous> (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/zapier-platform-core/src/middleware.js:66:23)
      at bound (domain.js:287:14)
      at Object.runBound (domain.js:300:12)
      at Object.tryCatcher (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/promise.js:510:31)
      at Promise._settlePromise (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/promise.js:567:18)
      at Promise._settlePromise0 (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/promise.js:612:10)
      at Promise._settlePromises (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/promise.js:691:18)
      at Async._drainQueue (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/async.js:138:16)
      at Async._drainQueues (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/async.js:148:10)
      at Immediate.Async.drainQueues [as _onImmediate] (/Users/fokkezb/git/zapier-platform-example-app-oauth2/node_modules/bluebird/js/release/async.js:17:14)
      at processImmediate [as _immediateCallback] (timers.js:383:17)
```

I RFC because I wonder if it would be better to just always include authData object in the bundle?