### PR TITLE
Fix doc typo RE: `module.exports` in snippets/app-def.js

### DIFF
--- a/snippets/app-def.js
+++ b/snippets/app-def.js
@@ -32,4 +32,4 @@ const App = {
   }
 };
 
-module.export = App;
+module.exports = App;


### PR DESCRIPTION
Hi there,

I noticed a small typo in your [docs](https://zapier.github.io/zapier-platform-cli/#local-app-definition) for declaring + exporting an `App` definition.

Right now it reads:

> module.export = App;

...when you actually need:

> module.export**s** = App;

This PR just adds the missing "s".

Thanks!
Matt