### PR TITLE
Version checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "read": "1.0.7",
     "string-length": "1.0.1",
     "through2": "2.0.1",
-    "tmp": "0.0.28"
+    "tmp": "0.0.28",
+    "update-notifier": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.14.0",

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -13,7 +13,7 @@ const test = (context) => {
     extraEnv.DETAILED_LOG_TO_STDOUT = 'true';
   }
 
-  if (!utils.correctVersion()) {
+  if (!utils.isCorrectVersion(context)) {
     process.exitCode = 1;
     return Promise.resolve();
   }

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const constants = require('../constants');
 const utils = require('../utils');
-const LAMBDA_VERSION = 'v4.3.2';
+
 
 const test = (context) => {
   const extraEnv = {};
@@ -13,8 +13,7 @@ const test = (context) => {
     extraEnv.DETAILED_LOG_TO_STDOUT = 'true';
   }
 
-  if (process.version !== LAMBDA_VERSION) {
-    context.line(`You're running tests on Node ${process.version}, but Zapier runs your code on ${LAMBDA_VERSION}. The version numbers must match. See https://zapier.github.io/zapier-platform-cli/index.html#requirements for more info.`);
+  if (!utils.correctVersion()) {
     process.exitCode = 1;
     return Promise.resolve();
   }

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -54,7 +54,7 @@ const validate = (context) => {
       }
     })
     .then(() => {
-      if (!utils.correctVersion(context)) {
+      if (!utils.isCorrectVersion(context)) {
         process.exitCode = 1;
       }
     })

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -54,6 +54,11 @@ const validate = (context) => {
       }
     })
     .then(() => {
+      if (!utils.correctVersion(context)) {
+        process.exitCode = 1;
+      }
+    })
+    .then(() => {
       if (global.argOpts['include-style']) {
         utils.localAppCommand({ command: 'definition' })
           .then((rawDefinition) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ const PLATFORM_PACKAGE = 'zapier-platform-core';
 const BUILD_DIR = 'build';
 const DEFINITION_PATH = `${BUILD_DIR}/definition.json`;
 const BUILD_PATH = `${BUILD_DIR}/build.zip`;
+const LAMBDA_VERSION = 'v4.3.2';
 
 const ART = `\
                 zzzzzzzz
@@ -36,17 +37,18 @@ zzzzzzzzzzzzzzz          zzzzzzzzzzzzzzz
                 zzzzzzzz`;
 
 module.exports = {
-  DEBUG,
-  BASE_ENDPOINT,
   API_PATH,
-  ENDPOINT,
-  STARTER_REPO,
-  AUTH_LOCATION_RAW,
+  ART,
   AUTH_LOCATION,
-  CURRENT_APP_FILE,
-  PLATFORM_PACKAGE,
-  DEFINITION_PATH,
+  AUTH_LOCATION_RAW,
+  BASE_ENDPOINT,
   BUILD_DIR,
   BUILD_PATH,
-  ART
+  CURRENT_APP_FILE,
+  DEBUG,
+  DEFINITION_PATH,
+  ENDPOINT,
+  LAMBDA_VERSION,
+  PLATFORM_PACKAGE,
+  STARTER_REPO
 };

--- a/src/entry.js
+++ b/src/entry.js
@@ -22,6 +22,8 @@ module.exports = (argv) => {
     process.exit(1);
   }
 
+  require('update-notifier')({ pkg: require('../package.json') }).notify();
+
   if (DEBUG) {
     console.log('running in:', process.cwd());
     console.log('raw argv:', argv);

--- a/src/utils/correct-version.js
+++ b/src/utils/correct-version.js
@@ -1,6 +1,6 @@
 const LAMBDA_VERSION = require('../constants').LAMBDA_VERSION;
 
-const correctVersion = (context) => {
+const isCorrectVersion = (context) => {
   if (process.version !== LAMBDA_VERSION) {
     context.line(`You're performing commands on Node ${process.version}, but Zapier runs your code on ${LAMBDA_VERSION}. The version numbers must match. See https://zapier.github.io/zapier-platform-cli/index.html#requirements for more info.`);
     return false;
@@ -10,5 +10,5 @@ const correctVersion = (context) => {
 };
 
 module.exports = {
-  correctVersion
+  isCorrectVersion
 };

--- a/src/utils/correct-version.js
+++ b/src/utils/correct-version.js
@@ -1,0 +1,14 @@
+const LAMBDA_VERSION = require('../constants').LAMBDA_VERSION;
+
+const correctVersion = (context) => {
+  if (process.version !== LAMBDA_VERSION) {
+    context.line(`You're performing commands on Node ${process.version}, but Zapier runs your code on ${LAMBDA_VERSION}. The version numbers must match. See https://zapier.github.io/zapier-platform-cli/index.html#requirements for more info.`);
+    return false;
+  } else {
+    return true;
+  }
+};
+
+module.exports = {
+  correctVersion
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,15 +2,16 @@ const _ = require('lodash');
 
 module.exports = _.extend(
   {},
-  require('./context'),
-  require('./files'),
-  require('./display'),
   require('./api'),
-  require('./misc'),
-  require('./local'),
   require('./args'),
   require('./build'),
-  require('./promisify'),
+  require('./context'),
+  require('./convert'),
+  require('./correct-version'),
+  require('./display'),
+  require('./files'),
   require('./init'),
-  require('./convert')
+  require('./local'),
+  require('./misc'),
+  require('./promisify'),
 );


### PR DESCRIPTION
Per discussion [here](https://zapier.slack.com/archives/C03TB1UMA/p1496344685110656), check version in 2 ways:

* during validation and testing. plus that function is broken out into a function, so we can add it wherever
* add the super cool [update-notifier](https://github.com/yeoman/update-notifier), which bugs the user daily (configurable, that's the default) if there's a newer version on npm that they're not using. 