### PR TITLE
require an exact core version in package.json

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -62,7 +62,7 @@ module.exports = (argv) => {
 
   if (!utils.isValidAppInstall(command)) {
     console.error(colors.red(
-      `Looks like your package.json is missing ${PLATFORM_PACKAGE} or you haven't run npm install yet!`
+      `Looks like your package.json is missing \`${PLATFORM_PACKAGE}\`, its version is a range, or you haven't run npm install yet!`
     ));
     process.exit(1);
   }

--- a/src/entry.js
+++ b/src/entry.js
@@ -62,7 +62,7 @@ module.exports = (argv) => {
 
   if (!utils.isValidAppInstall(command)) {
     console.error(colors.red(
-      `Looks like your package.json is missing \`${PLATFORM_PACKAGE}\`, its version is a range, or you haven't run npm install yet!`
+      `Looks like your package.json is missing \`${PLATFORM_PACKAGE}\`, its not restricted to a single version, or you haven't run npm install yet!`
     ));
     process.exit(1);
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -94,7 +94,10 @@ const callAPI = (route, options) => {
 
       if (constants.DEBUG || global.argOpts.debug) {
         console.log(`>> ${requestOptions.method} ${requestOptions.url}`);
-        if (requestOptions.body) { console.log(`>> ${requestOptions.body}`); }
+        if (requestOptions.body) {
+          let cleanedBody = _.assign({}, JSON.parse(requestOptions.body), {zip_file: 'raw zip removed in logs'});
+          console.log(`>> ${JSON.stringify(cleanedBody)}`);
+        }
         console.log(`<< ${res.status}`);
         console.log(`<< ${(text || '').substring(0, 2500)}\n`);
       } else if (hitError) {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -86,13 +86,18 @@ const isValidNodeVersion = () => {
 };
 
 const isValidAppInstall = (command) => {
-  if (command === 'help' || command === 'init' || command === 'login' || command === 'apps' || command === 'convert') {
+  if (['help', 'init', 'login', 'apps', 'convert'].includes(command)) {
     return true;
   }
 
   let packageJson;
   try {
     packageJson = require(path.join(process.cwd(), 'package.json'));
+    const coreVersion = packageJson.dependencies[PLATFORM_PACKAGE];
+    // could check for a lot more, but this is probably enough: https://docs.npmjs.com/files/package.json#dependencies
+    if (!coreVersion || coreVersion.includes('^')) {
+      return false;
+    }
   } catch(err) {
     return false;
   }


### PR DESCRIPTION
This will resolve the server not knowing what to do with core version `^2.0.0` as discussed [here](https://zapier.slack.com/archives/C151BFEJ3/p1498842593194328). `npm` lets you define a range in a lot of ways, so we wanted to check other characters, we could. 

Also have some small miscellaneous fixes, such as not showing a huge raw zip if `zapier build` is run with `--debug` (not useful, makes good logs hard to find).