### PR TITLE
Script enhancement for set-app-template-versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
     "lodash": "4.17.4",
     "node-fetch": "1.7.1",
     "read": "1.0.7",
-    "semver": "5.3.0",
     "string-length": "1.0.1",
     "through2": "2.0.3",
     "tmp": "0.0.31",
-    "update-notifier": "2.2.0",
-    "yamljs": "0.3.0"
+    "update-notifier": "2.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
@@ -57,7 +55,9 @@
     "mocha": "3.4.2",
     "ngrok": "2.2.10",
     "node-watch": "0.5.4",
-    "should": "11.2.1"
+    "semver": "5.3.0",
+    "should": "11.2.1",
+    "yamljs": "0.3.0"
   },
   "bin": {
     "zapier": "zapier.js"

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "lodash": "4.17.4",
     "node-fetch": "1.7.1",
     "read": "1.0.7",
+    "semver": "5.3.0",
     "string-length": "1.0.1",
     "through2": "2.0.3",
     "tmp": "0.0.31",
-    "update-notifier": "2.2.0"
+    "update-notifier": "2.2.0",
+    "yamljs": "0.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/scripts/set-app-template-versions.js
+++ b/scripts/set-app-template-versions.js
@@ -13,6 +13,8 @@ const yaml = require('yamljs');
 const childProcess = utils.promisifyAll(require('child_process'));
 
 const CLONE_URL_PREFIX = 'git@github.com:zapier/zapier-platform-example-app';
+const PACKAGES_NAMES = `node, npm, and zapier-platform-core`;
+let packagesVersions;
 
 const newCoreVersion = process.argv[2];
 if (!newCoreVersion) {
@@ -51,8 +53,9 @@ const setVersion = (template, rootTmpDir) => {
   const repoDir = path.resolve(rootTmpDir, repoName);
   const cloneUrl = `${CLONE_URL_PREFIX}-${template}`;
   var cmd = `git clone ${cloneUrl}`;
+  packagesVersions = `${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion}`;
 
-  console.log(`Setting versions of node, npm, and zapier-platform-core to ${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion} respectively in ${template} app template.`);
+  console.log(`Setting versions of ${PACKAGES_NAMES} to ${packagesVersions} respectively in ${template} app template.`);
   console.log(`cloning ${cloneUrl}\n`);
 
   return exec(cmd, rootTmpDir)
@@ -86,7 +89,7 @@ const setVersion = (template, rootTmpDir) => {
         return result;
       }
 
-      cmd = `git commit package.json .nvmrc .travis.yml -m "update node, npm, and zapier-platform-core versions to ${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion} respectively."`;
+      cmd = `git commit package.json .nvmrc .travis.yml -m "update ${PACKAGES_NAMES} versions to ${packagesVersions} respectively."`;
       return exec(cmd, repoDir);
     })
     .then(result => {
@@ -99,14 +102,14 @@ const setVersion = (template, rootTmpDir) => {
     })
     .then(result => {
       if (result === 'skip') {
-        console.log(`${template} is already set to ${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion} for node, npm, and zapier-platform-core respectively, skipping`);
+        console.log(`${template} is already set to ${packagesVersions} for ${PACKAGES_NAMES} respectively, skipping`);
         return 'skip';
       }
-      console.log(`Set node, npm, and zapier-platform-core versions to ${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion} respectively on app template ${template} successfully.`);
+      console.log(`Set ${PACKAGES_NAMES} versions to ${packagesVersions} respectively on app template ${template} successfully.`);
       return null;
     })
     .catch(err => {
-      console.error(`Error setting node, npm, and zapier-platform-core versions for app template ${template}:`, err);
+      console.error(`Error setting ${PACKAGES_NAMES} versions for app template ${template}:`, err);
       return template;
     });
 };
@@ -124,10 +127,10 @@ Promise.all(tasks)
     const successCount = tasks.length - failures.length - skipped.length;
 
     if (failures.length) {
-      console.error('failed to set node, npm, and zapier-platform-core versions on these templates:', failures.join(', '));
+      console.error('failed to set ${PACKAGES_NAMES} versions on these templates:', failures.join(', '));
     }
     if (skipped.length) {
-      console.log(`skipped ${skipped.length} templates because versions for node, npm, and zapier-platform-core were already set to ${newVersions.nodeVersion}, ${newVersions.npmVersion}, and ${newVersions.coreVersion} respectively`);
+      console.log(`skipped ${skipped.length} templates because versions for ${PACKAGES_NAMES} were already set to ${packagesVersions} respectively`);
     }
     if (successCount) {
       console.log(`Successfully updated versions in ${successCount} app templates`);

--- a/scripts/set-app-template-versions.js
+++ b/scripts/set-app-template-versions.js
@@ -5,7 +5,7 @@ const path = require('path');
 const tmp = require('tmp');
 const utils = require('../lib/utils');
 const appTemplates = require('../lib/app-templates');
-const versionMap = require('../lib/version-map');
+const versionStore = require('../lib/version-store');
 
 const fse = require('fs-extra');
 const semver = require('semver');
@@ -21,7 +21,7 @@ if (!newCoreVersion) {
   process.exit(1);
 }
 
-const newVersions = versionMap[semver.parse(newCoreVersion).major];
+const newVersions = versionStore[semver.parse(newCoreVersion).major];
 newVersions.coreVersion = newCoreVersion;
 
 const exec = (cmd, cwd) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 const os = require('os');
 const path = require('path');
 const semver = require('semver');
-const versionMap = require('./version-map');
+const versionStore = require('./version-store');
 
 const DEBUG = (process.env.ZAPIER_DEBUG || 'false') === 'true';
 
@@ -16,7 +16,7 @@ const PLATFORM_PACKAGE = 'zapier-platform-core';
 const BUILD_DIR = 'build';
 const DEFINITION_PATH = `${BUILD_DIR}/definition.json`;
 const BUILD_PATH = `${BUILD_DIR}/build.zip`;
-const nodeVersion = semver.Comparator(versionMap[versionMap.length - 1].nodeVersion).semver.version;
+const nodeVersion = semver.Comparator(versionStore[versionStore.length - 1].nodeVersion).semver.version;
 const LAMBDA_VERSION = `v${nodeVersion}`;
 
 const ART = `\

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
 const os = require('os');
 const path = require('path');
+const semver = require('semver');
+const versionMap = require('./version-map');
 
 const DEBUG = (process.env.ZAPIER_DEBUG || 'false') === 'true';
 
@@ -14,7 +16,8 @@ const PLATFORM_PACKAGE = 'zapier-platform-core';
 const BUILD_DIR = 'build';
 const DEFINITION_PATH = `${BUILD_DIR}/definition.json`;
 const BUILD_PATH = `${BUILD_DIR}/build.zip`;
-const LAMBDA_VERSION = 'v6.10.2';
+const nodeVersion = semver.Comparator(versionMap[versionMap.length - 1].nodeVersion).semver.version;
+const LAMBDA_VERSION = `v${nodeVersion}`;
 
 const ART = `\
                 zzzzzzzz

--- a/src/version-map.js
+++ b/src/version-map.js
@@ -1,0 +1,7 @@
+// Index of each item is equivalent to the major of zapier-platform-core version.
+// The next item will be for zapier-platform-core version of major 3.
+module.exports = [
+	{nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
+	{nodeVersion: '>=4.3.2', npmVersion:'>=2.14.12'},
+	{nodeVersion: '>=6.10.2', npmVersion: '>=3.10.10'}
+]

--- a/src/version-store.js
+++ b/src/version-store.js
@@ -1,7 +1,7 @@
 // Index of each item is equivalent to the major of zapier-platform-core version.
 // The next item will be for zapier-platform-core version of major 3.
 module.exports = [
-  {nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
-  {nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
-  {nodeVersion: '>=6.10.2', npmVersion: '>=3.10.10'}
+  {nodeVersion: '4.3.2', npmVersion: '>=2.14.12'},
+  {nodeVersion: '4.3.2', npmVersion: '>=2.14.12'},
+  {nodeVersion: '6.10.2', npmVersion: '>=3.10.10'}
 ];

--- a/src/version-store.js
+++ b/src/version-store.js
@@ -1,7 +1,7 @@
 // Index of each item is equivalent to the major of zapier-platform-core version.
 // The next item will be for zapier-platform-core version of major 3.
 module.exports = [
-	{nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
-	{nodeVersion: '>=4.3.2', npmVersion:'>=2.14.12'},
-	{nodeVersion: '>=6.10.2', npmVersion: '>=3.10.10'}
-]
+  {nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
+  {nodeVersion: '>=4.3.2', npmVersion: '>=2.14.12'},
+  {nodeVersion: '>=6.10.2', npmVersion: '>=3.10.10'}
+];


### PR DESCRIPTION
This makes it possible to update the node and npm versions in the package.json file, the node version in the .nvmrc file, and the node_js version in the .travis.yml file of the app templates along with the version update for the zapier-platform-core in the package.json file.

Instead of the hardcoded value, the `LAMBDA_VERSION` constant is now gotten from a central source for versions. 

P.S. [Here](https://zapier.slack.com/archives/C151BFEJ3/p1498854268714539) is the Slack discussion on the need for it.