### PR TITLE
Adding warning when a build is uploaded with an outdated core version.

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -1193,6 +1193,36 @@ source ~/.bash_completion.d/_zapier
 
 Finally, restart your shell and start hitting TAB with the `zapier` command!
 
+## Upgrading Zapier Platform CLI or Zapier Platform Core
+
+The CLI version of the Platform has 3 public packages:
+
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli): This is the `zapier` command. Should be installed with `npm install -g zapier-platform-cli` and is used to interact with your app and Zapier, but doesn't run in nor is included by your app.
+
+- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core): This is what allows your app to interact with Zapier. Apps require this package in their `package.json` file, and a specific version by design, so you can keep using an older "core" version without having to upgrade your code, but still being able to update your app. Should be installed with `npm install` in your app. You should manually keep this version number in sync with your `zapier-platform-cli` global one, but it's not required for all upgrades.
+
+- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema): This is a separate package for maintainability purposes. It's a dependency installed automatically by `zapier-platform-core`. It's basically the package that enforces app schemas to match what Zapier has in the backend.
+
+### Upgrading Zapier Platform CLI
+
+Check your version with `$ zapier --version` and update with `$ npm -g update zapier-platform-cli`.
+
+You can also [look at the Changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to understand what changed between versions.
+
+#### When to update CLI
+
+You should keep your `zapier-platform-cli` global package up-to-date to get the latest features and bug fixes for interacting with your app, but it's not mandatory. You should be able to use any publicly available `zapier-platform-cli` version.
+
+### Upgrading Zapier Platform Core
+
+Open your app's `package.json` file and update the number for the `zapier-platform-core` entry to what the latest public version is. You can see it on the right side of the [NPM registry page](https://www.npmjs.com/package/zapier-platform-core). After that you should be able to run `npm update` and get the latest goodies!
+
+#### When to update Core
+
+You should keep your `zapier-platform-core` package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it's not mandatory. You should be able to use any publicly available `zapier-platform-core` version.
+
+While not always required, it's also recommended you use the same `zapier-platform-cli` global package as the app's `zapier-platform-core` one, to ensure maximum compatibility.
+
 ## Development of the CLI
 
 - `export ZAPIER_BASE_ENDPOINT='http://localhost:8000'` if you're building against a local dev environment

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 - [Command line Tab Completion](#command-line-tab-completion)
   * [Zsh Completion Script](#zsh-completion-script)
   * [Bash Completion Script](#bash-completion-script)
+- [Upgrading Zapier Platform CLI or Zapier Platform Core](#upgrading-zapier-platform-cli-or-zapier-platform-core)
+  * [Upgrading Zapier Platform CLI](#upgrading-zapier-platform-cli)
+    + [When to update CLI](#when-to-update-cli)
+  * [Upgrading Zapier Platform Core](#upgrading-zapier-platform-core)
+    + [When to update Core](#when-to-update-core)
 - [Development of the CLI](#development-of-the-cli)
 - [Publishing of the CLI (after merging)](#publishing-of-the-cli-after-merging)
 - [Get Help!](#get-help)
@@ -1953,6 +1958,36 @@ source ~/.bash_completion.d/_zapier
 ```
 
 Finally, restart your shell and start hitting TAB with the `zapier` command!
+
+## Upgrading Zapier Platform CLI or Zapier Platform Core
+
+The CLI version of the Platform has 3 public packages:
+
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli): This is the `zapier` command. Should be installed with `npm install -g zapier-platform-cli` and is used to interact with your app and Zapier, but doesn't run in nor is included by your app.
+
+- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core): This is what allows your app to interact with Zapier. Apps require this package in their `package.json` file, and a specific version by design, so you can keep using an older "core" version without having to upgrade your code, but still being able to update your app. Should be installed with `npm install` in your app. You should manually keep this version number in sync with your `zapier-platform-cli` global one, but it's not required for all upgrades.
+
+- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema): This is a separate package for maintainability purposes. It's a dependency installed automatically by `zapier-platform-core`. It's basically the package that enforces app schemas to match what Zapier has in the backend.
+
+### Upgrading Zapier Platform CLI
+
+Check your version with `$ zapier --version` and update with `$ npm -g update zapier-platform-cli`.
+
+You can also [look at the Changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to understand what changed between versions.
+
+#### When to update CLI
+
+You should keep your `zapier-platform-cli` global package up-to-date to get the latest features and bug fixes for interacting with your app, but it's not mandatory. You should be able to use any publicly available `zapier-platform-cli` version.
+
+### Upgrading Zapier Platform Core
+
+Open your app's `package.json` file and update the number for the `zapier-platform-core` entry to what the latest public version is. You can see it on the right side of the [NPM registry page](https://www.npmjs.com/package/zapier-platform-core). After that you should be able to run `npm update` and get the latest goodies!
+
+#### When to update Core
+
+You should keep your `zapier-platform-core` package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it's not mandatory. You should be able to use any publicly available `zapier-platform-core` version.
+
+While not always required, it's also recommended you use the same `zapier-platform-cli` global package as the app's `zapier-platform-core` one, to ensure maximum compatibility.
 
 ## Development of the CLI
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -321,6 +321,17 @@ a code {
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
 </ul>
 </li>
+<li><a href="#upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</a><ul>
+<li><a href="#upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</a><ul>
+<li><a href="#when-to-update-cli">When to update CLI</a></li>
+</ul>
+</li>
+<li><a href="#upgrading-zapier-platform-core">Upgrading Zapier Platform Core</a><ul>
+<li><a href="#when-to-update-core">When to update Core</a></li>
+</ul>
+</li>
+</ul>
+</li>
 <li><a href="#development-of-the-cli">Development of the CLI</a></li>
 <li><a href="#publishing-of-the-cli-after-merging">Publishing of the CLI (after merging)</a></li>
 <li><a href="#get-help">Get Help!</a></li>
@@ -478,6 +489,17 @@ a code {
 <li><a href="#command-line-tab-completion">Command line Tab Completion</a><ul>
 <li><a href="#zsh-completion-script">Zsh Completion Script</a></li>
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
+</ul>
+</li>
+<li><a href="#upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</a><ul>
+<li><a href="#upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</a><ul>
+<li><a href="#when-to-update-cli">When to update CLI</a></li>
+</ul>
+</li>
+<li><a href="#upgrading-zapier-platform-core">Upgrading Zapier Platform Core</a><ul>
+<li><a href="#when-to-update-core">When to update Core</a></li>
+</ul>
+</li>
 </ul>
 </li>
 <li><a href="#development-of-the-cli">Development of the CLI</a></li>
@@ -3446,6 +3468,103 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Finally, restart your shell and start hitting TAB with the <code>zapier</code> command!</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>The CLI version of the Platform has 3 public packages:</p><ul>
+<li><p><a href="https://github.com/zapier/zapier-platform-cli"><code>zapier-platform-cli</code></a>: This is the <code>zapier</code> command. Should be installed with <code>npm install -g zapier-platform-cli</code> and is used to interact with your app and Zapier, but doesn&apos;t run in nor is included by your app.</p>
+</li>
+<li><p><a href="https://github.com/zapier/zapier-platform-core"><code>zapier-platform-core</code></a>: This is what allows your app to interact with Zapier. Apps require this package in their <code>package.json</code> file, and a specific version by design, so you can keep using an older &quot;core&quot; version without having to upgrade your code, but still being able to update your app. Should be installed with <code>npm install</code> in your app. You should manually keep this version number in sync with your <code>zapier-platform-cli</code> global one, but it&apos;s not required for all upgrades.</p>
+</li>
+<li><p><a href="https://github.com/zapier/zapier-platform-schema"><code>zapier-platform-schema</code></a>: This is a separate package for maintainability purposes. It&apos;s a dependency installed automatically by <code>zapier-platform-core</code>. It&apos;s basically the package that enforces app schemas to match what Zapier has in the backend.</p>
+</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Check your version with <code>$ zapier --version</code> and update with <code>$ npm -g update zapier-platform-cli</code>.</p><p>You can also <a href="https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md">look at the Changelog</a> to understand what changed between versions.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h4 id="when-to-update-cli">When to update CLI</h4>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>You should keep your <code>zapier-platform-cli</code> global package up-to-date to get the latest features and bug fixes for interacting with your app, but it&apos;s not mandatory. You should be able to use any publicly available <code>zapier-platform-cli</code> version.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="upgrading-zapier-platform-core">Upgrading Zapier Platform Core</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Open your app&apos;s <code>package.json</code> file and update the number for the <code>zapier-platform-core</code> entry to what the latest public version is. You can see it on the right side of the <a href="https://www.npmjs.com/package/zapier-platform-core">NPM registry page</a>. After that you should be able to run <code>npm update</code> and get the latest goodies!</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h4 id="when-to-update-core">When to update Core</h4>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>You should keep your <code>zapier-platform-core</code> package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it&apos;s not mandatory. You should be able to use any publicly available <code>zapier-platform-core</code> version.</p><p>While not always required, it&apos;s also recommended you use the same <code>zapier-platform-cli</code> global package as the app&apos;s <code>zapier-platform-core</code> one, to ensure maximum compatibility.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lodash": "4.17.4",
     "node-fetch": "1.7.1",
     "read": "1.0.7",
+    "semver": "5.3.0",
     "string-length": "1.0.1",
     "through2": "2.0.3",
     "tmp": "0.0.31",
@@ -55,7 +56,6 @@
     "mocha": "3.4.2",
     "ngrok": "2.2.10",
     "node-watch": "0.5.4",
-    "semver": "5.3.0",
     "should": "11.2.1",
     "yamljs": "0.3.0"
   },

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -271,7 +271,7 @@ const upload = (zipPath, appDir) => {
       printDone();
 
       if (semver.lt(appVersion.platform_version, appVersion.core_npm_version)) {
-        console.log(`\n**NOTE:** Your app is using zapier-platform-core@${appVersion.platform_version}, and there's a new version: ${appVersion.core_npm_version}. Please consider updating it: https://zapier.com/developer/documentation/v2/upgrading-zapier-platform-cli-or-zapier-platform-core/`);
+        console.log(`\n**NOTE:** Your app is using zapier-platform-core@${appVersion.platform_version}, and there's a new version: ${appVersion.core_npm_version}. Please consider updating it: https://zapier.github.io/zapier-platform-cli/#upgrading-zapier-platform-cli-or-zapier-platform-core`);
       }
     });
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const AdmZip = require('adm-zip');
 const fetch = require('node-fetch');
 const path = require('path');
+const semver = require('semver');
 
 const {
   writeFile,
@@ -258,7 +259,7 @@ const upload = (zipPath, appDir) => {
       const binaryZip = fs.readFileSync(fullZipPath);
       const buffer = new Buffer(binaryZip).toString('base64');
 
-      printStarting('Uploading version ' + definition.version);
+      printStarting(`Uploading version ${definition.version}`);
       return callAPI(`/apps/${app.id}/versions/${definition.version}`, {
         method: 'PUT',
         body: {
@@ -266,8 +267,12 @@ const upload = (zipPath, appDir) => {
         }
       });
     })
-    .then(() => {
+    .then((appVersion) => {
       printDone();
+
+      if (semver.lt(appVersion.platform_version, appVersion.core_npm_version)) {
+        console.log(`\n**NOTE:** Your app is using zapier-platform-core@${appVersion.platform_version}, and there's a new version: ${appVersion.core_npm_version}. Please consider updating it: https://zapier.com/developer/documentation/v2/upgrading-zapier-platform-cli-or-zapier-platform-core/`);
+      }
     });
 };
 


### PR DESCRIPTION
Related to https://github.com/zapier/zapier/pull/12836 and needs it shipped before this can ship.

Sample screenshot:

<img width="1440" alt="cli-needs-update" src="https://user-images.githubusercontent.com/1239616/28928235-9fecdb0e-7864-11e7-8292-e84a155c51da.png">
