### PR TITLE
Add Onedrive as a valid template

### DIFF
--- a/src/app-templates.js
+++ b/src/app-templates.js
@@ -14,4 +14,5 @@ module.exports = [
   'babel',
   'rest-hooks',
   'files',
+  'onedrive'
 ];


### PR DESCRIPTION
We just published https://github.com/zapier/zapier-platform-example-app-onedrive

This makes it so that `zapier init --template=onedrive ./` works!