### PR TITLE
Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ const App = {
       // `display` controls the presentation in the Zapier Editor
       display: {
         label: 'New Recipe',
-        helpText: 'Triggers when a new recipe is added.'
+        description: 'Triggers when a new recipe is added.'
       },
       // `operation` implements the API call used to fetch the data
       operation: {
@@ -1518,7 +1518,7 @@ const App = {
       noun: 'Movie',
       display: {
         label: 'New Movie',
-        helpText: 'Triggers when a new Movie is added.'
+        description: 'Triggers when a new Movie is added.'
       },
       operation: {
         perform: movieList
@@ -1602,7 +1602,7 @@ const App = {
       noun: 'PDF',
       display: {
         label: 'New PDF',
-        helpText: 'Triggers when a new PDF is added.'
+        description: 'Triggers when a new PDF is added.'
       },
       operation: {
         perform: pdfList

--- a/docs/index.html
+++ b/docs/index.html
@@ -1560,7 +1560,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <span class="hljs-comment">// `display` controls the presentation in the Zapier Editor</span>
       display: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New Recipe&apos;</span>,
-        <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Triggers when a new recipe is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new recipe is added.&apos;</span>
       },
       <span class="hljs-comment">// `operation` implements the API call used to fetch the data</span>
       operation: {
@@ -2694,7 +2694,7 @@ zapier env 1.0.0
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;Movie&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New Movie&apos;</span>,
-        <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>
       },
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-attr">perform</span>: movieList
@@ -2800,7 +2800,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;PDF&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New PDF&apos;</span>,
-        <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>
       },
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-attr">perform</span>: pdfList

--- a/snippets/dehydration.js
+++ b/snippets/dehydration.js
@@ -34,7 +34,7 @@ const App = {
       noun: 'Movie',
       display: {
         label: 'New Movie',
-        helpText: 'Triggers when a new Movie is added.'
+        description: 'Triggers when a new Movie is added.'
       },
       operation: {
         perform: movieList

--- a/snippets/stash-file.js
+++ b/snippets/stash-file.js
@@ -37,7 +37,7 @@ const App = {
       noun: 'PDF',
       display: {
         label: 'New PDF',
-        helpText: 'Triggers when a new PDF is added.'
+        description: 'Triggers when a new PDF is added.'
       },
       operation: {
         perform: pdfList

--- a/snippets/trigger.js
+++ b/snippets/trigger.js
@@ -11,7 +11,7 @@ const App = {
       // `display` controls the presentation in the Zapier Editor
       display: {
         label: 'New Recipe',
-        helpText: 'Triggers when a new recipe is added.'
+        description: 'Triggers when a new recipe is added.'
       },
       // `operation` implements the API call used to fetch the data
       operation: {


### PR DESCRIPTION
Some code examples in the documentation were showing "helpText" instead of "description" in the display object, which doesn't match up with the schema documentation.