### PR TITLE
Fix broken z.request in scaffold

### DIFF
--- a/scaffold/create.template.js
+++ b/scaffold/create.template.js
@@ -3,7 +3,7 @@ const create<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
     method: 'POST',
     url: 'http://example.com/api/<%= KEY %>s.json',
-    data: JSON.stringify({
+    body: JSON.stringify({
       name: bundle.inputData.name
     })
   });


### PR DESCRIPTION
**Use `body` instead of `data` in z.request** (870db70)

`data` is how we do this in web builder, but CLI is different — we send
data with z.request in CLI under the `body`, `json`, or `form` key:

https://github.com/zapier/zapier-platform-cli#http-request-options