### PR TITLE
fix: exit code 1 for only for errors

### DIFF
--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -83,7 +83,8 @@ const validate = (context) => {
         ['Link', 'link']
       ], ifEmpty, true);
 
-      if (styleErrors.length) {
+      // exit code 1 only for errors and not warnings
+      if (styleErrors.filter((error) => error.category === 'errors').length) {
         process.exitCode = 1;
         context.line('Errors will prevent promotions, warnings are things to improve on.\n');
       } else {


### PR DESCRIPTION
Currently when `zapier test` is run, it terminates with exit code 1, when just warnings are returned during style check validation. Warnings are not critical IMHO. This behaviour breaks builds indiscriminately, even when the warning doesn't necessarily apply to the project.

A current work around is to run with `--skip-validate`, but then this takes away other benefits of running the validation, like identifying actual errors for example.

This PR changes the behavior to only terminate with exit code 1 for actual errors and not warnings. :)