### PR TITLE
DocFix: Errors are under z.errors

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -991,7 +991,7 @@ This would indicate failure, but it would be treated as a soft failure.
 Unlike throwing `Error`, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).
 
-Example: `throw z.errors.HaltedError('Your reason.');`
+Example: `throw new z.errors.HaltedError('Your reason.');`
 
 ### Stale Authentication Credentials
 

--- a/README-source.md
+++ b/README-source.md
@@ -991,7 +991,7 @@ This would indicate failure, but it would be treated as a soft failure.
 Unlike throwing `Error`, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).
 
-Example: `throw new HaltedError('Your reason.');`
+Example: `throw z.errors.HaltedError('Your reason.');`
 
 ### Stale Authentication Credentials
 
@@ -1001,13 +1001,13 @@ provides a mechanism to notify users of expired credentials. With the
 (to prevent more calls with expired credentials), and a predefined email is sent
 out informing the user to refresh the credentials.
 
-Example: `throw new ExpiredAuthError('Your message.');`
+Example: `throw new z.errors.ExpiredAuthError('Your message.');`
 
 For apps that use OAuth2 + refresh or Session Auth, you can use the
 `RefreshAuthError`. This will signal Zapier to refresh the credentials and then
 repeat the failed operation.
 
-Example: `throw new RefreshAuthError();`
+Example: `throw new z.errors.RefreshAuthError();`
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1718,7 +1718,7 @@ This would indicate failure, but it would be treated as a soft failure.
 Unlike throwing `Error`, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).
 
-Example: `throw z.errors.HaltedError('Your reason.');`
+Example: `throw new z.errors.HaltedError('Your reason.');`
 
 ### Stale Authentication Credentials
 

--- a/README.md
+++ b/README.md
@@ -1718,7 +1718,7 @@ This would indicate failure, but it would be treated as a soft failure.
 Unlike throwing `Error`, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).
 
-Example: `throw new HaltedError('Your reason.');`
+Example: `throw z.errors.HaltedError('Your reason.');`
 
 ### Stale Authentication Credentials
 
@@ -1728,13 +1728,13 @@ provides a mechanism to notify users of expired credentials. With the
 (to prevent more calls with expired credentials), and a predefined email is sent
 out informing the user to refresh the credentials.
 
-Example: `throw new ExpiredAuthError('Your message.');`
+Example: `throw new z.errors.ExpiredAuthError('Your message.');`
 
 For apps that use OAuth2 + refresh or Session Auth, you can use the
 `RefreshAuthError`. This will signal Zapier to refresh the credentials and then
 repeat the failed operation.
 
-Example: `throw new RefreshAuthError();`
+Example: `throw new z.errors.RefreshAuthError();`
 
 
 ## Testing

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -754,13 +754,12 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Manage the invitees/testers on your project. Can optionally specify a version or --remove.</p>
-</blockquote><p>  <strong>Usage:</strong> <code>zapier invite [user@example.com] [1.0.0]</code></p><p>Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your app versions. If you&apos;d like to provide full admin access, try <code>zapier collaborate</code>.</p><blockquote>
+<p>Manage the invitees/testers on your project. Can optionally --remove.</p>
+</blockquote><p>  <strong>Usage:</strong> <code>zapier invite [user@example.com]</code></p><p>Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your apps. If you&apos;d like to provide full admin access, try <code>zapier collaborate</code>.</p><blockquote>
 <p>Send an email directly, which contains a one-time use link for them only - or share the public URL to &quot;bulk&quot; invite folks!</p>
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><em>none</em> -- print all invitees</li>
 <li><code>email [user@example.com]</code> -- <em>optional</em>, which user to add/remove</li>
-<li><code>version [1.0.0]</code> -- <em>optional</em>, only invite to a specific version</li>
 <li><code>--remove</code> -- <em>optional</em>, elect to remove this user</li>
 <li><code>--format={plain,json,raw,row,table,small}</code> -- <em>optional</em>, display format. Default is <code>table</code></li>
 <li><code>--help</code> -- <em>optional</em>, prints this help text</li>
@@ -770,19 +769,19 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">$ zapier invite
 <span class="hljs-comment"># The invitees on your app listed below.</span>
-
-<span class="hljs-comment"># &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;</span>
-<span class="hljs-comment"># &#x2502; Email             &#x2502; Role     &#x2502; Status   &#x2502; Version &#x2502;</span>
-<span class="hljs-comment"># &#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;</span>
-<span class="hljs-comment"># &#x2502; user@example.com  &#x2502; invitees &#x2502; accepted &#x2502; 1.0.0   &#x2502;</span>
-<span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
+<span class="hljs-comment">#</span>
+<span class="hljs-comment"># &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;</span>
+<span class="hljs-comment"># &#x2502; Email            &#x2502; Role    &#x2502; Status   &#x2502;</span>
+<span class="hljs-comment"># &#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;</span>
+<span class="hljs-comment"># &#x2502; user@example.com &#x2502; invitee &#x2502; accepted &#x2502;</span>
+<span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># Don&apos;t want to send individual invite emails? Use this public link and share with anyone on the web:</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment">#   https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/</span>
 
-$ zapier invite user@example.com 1.0.0
-<span class="hljs-comment"># Preparing to add invitee user@example.com to your app &quot;Example (1.0.0)&quot;.</span>
+$ zapier invite user@example.com
+<span class="hljs-comment"># Preparing to add invitee user@example.com to your app &quot;Example&quot;.</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment">#   Adding user@example.com - done!</span>
 <span class="hljs-comment">#</span>
@@ -937,7 +936,7 @@ All personal keys deactivated - now try `zapier login` to login again.
 <span class="hljs-comment"># &#x2502;     Timestamp &#x2502; 2016-01-01T23:04:36-05:00            &#x2502;</span>
 <span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 
-$ zapier logs --type=http
+$ zapier logs --<span class="hljs-built_in">type</span>=http
 <span class="hljs-comment"># The logs of your app &quot;Example&quot; listed below.</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;</span>
@@ -950,7 +949,7 @@ $ zapier logs --type=http
 <span class="hljs-comment"># &#x2502;     Timestamp   &#x2502; 2016-01-01T23:04:36-05:00            &#x2502;</span>
 <span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 
-$ zapier logs --type=http --detailed --format=plain
+$ zapier logs --<span class="hljs-built_in">type</span>=http --detailed --format=plain
 <span class="hljs-comment"># The logs of your app &quot;Example&quot; listed below.</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># == Status</span>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -754,12 +754,13 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Manage the invitees/testers on your project. Can optionally --remove.</p>
-</blockquote><p>  <strong>Usage:</strong> <code>zapier invite [user@example.com]</code></p><p>Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your apps. If you&apos;d like to provide full admin access, try <code>zapier collaborate</code>.</p><blockquote>
+<p>Manage the invitees/testers on your project. Can optionally specify a version or --remove.</p>
+</blockquote><p>  <strong>Usage:</strong> <code>zapier invite [user@example.com] [1.0.0]</code></p><p>Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your app versions. If you&apos;d like to provide full admin access, try <code>zapier collaborate</code>.</p><blockquote>
 <p>Send an email directly, which contains a one-time use link for them only - or share the public URL to &quot;bulk&quot; invite folks!</p>
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><em>none</em> -- print all invitees</li>
 <li><code>email [user@example.com]</code> -- <em>optional</em>, which user to add/remove</li>
+<li><code>version [1.0.0]</code> -- <em>optional</em>, only invite to a specific version</li>
 <li><code>--remove</code> -- <em>optional</em>, elect to remove this user</li>
 <li><code>--format={plain,json,raw,row,table,small}</code> -- <em>optional</em>, display format. Default is <code>table</code></li>
 <li><code>--help</code> -- <em>optional</em>, prints this help text</li>
@@ -769,19 +770,19 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">$ zapier invite
 <span class="hljs-comment"># The invitees on your app listed below.</span>
-<span class="hljs-comment">#</span>
-<span class="hljs-comment"># &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;</span>
-<span class="hljs-comment"># &#x2502; Email            &#x2502; Role    &#x2502; Status   &#x2502;</span>
-<span class="hljs-comment"># &#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;</span>
-<span class="hljs-comment"># &#x2502; user@example.com &#x2502; invitee &#x2502; accepted &#x2502;</span>
-<span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
+
+<span class="hljs-comment"># &#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x252C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;</span>
+<span class="hljs-comment"># &#x2502; Email             &#x2502; Role     &#x2502; Status   &#x2502; Version &#x2502;</span>
+<span class="hljs-comment"># &#x251C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x253C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2524;</span>
+<span class="hljs-comment"># &#x2502; user@example.com  &#x2502; invitees &#x2502; accepted &#x2502; 1.0.0   &#x2502;</span>
+<span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># Don&apos;t want to send individual invite emails? Use this public link and share with anyone on the web:</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment">#   https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/</span>
 
-$ zapier invite user@example.com
-<span class="hljs-comment"># Preparing to add invitee user@example.com to your app &quot;Example&quot;.</span>
+$ zapier invite user@example.com 1.0.0
+<span class="hljs-comment"># Preparing to add invitee user@example.com to your app &quot;Example (1.0.0)&quot;.</span>
 <span class="hljs-comment">#</span>
 <span class="hljs-comment">#   Adding user@example.com - done!</span>
 <span class="hljs-comment">#</span>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -447,12 +447,12 @@ $ zapier init example-app --template=minimal
 
 ## invite
 
-  > Manage the invitees/testers on your project. Can optionally specify a version or --remove.
+  > Manage the invitees/testers on your project. Can optionally --remove.
 
-  **Usage:** `zapier invite [user@example.com] [1.0.0]`
+  **Usage:** `zapier invite [user@example.com]`
 
   
-Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your app versions. If you'd like to provide full admin access, try `zapier collaborate`.
+Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your apps. If you'd like to provide full admin access, try `zapier collaborate`.
 
 > Send an email directly, which contains a one-time use link for them only - or share the public URL to "bulk" invite folks!
 
@@ -460,7 +460,6 @@ Invite any user registered on Zapier to test your app. Commonly, this is useful 
 
 * _none_ -- print all invitees
 * `email [user@example.com]` -- _optional_, which user to add/remove
-* `version [1.0.0]` -- _optional_, only invite to a specific version
 * `--remove` -- _optional_, elect to remove this user
 * `--format={plain,json,raw,row,table,small}` -- _optional_, display format. Default is `table`
 * `--help` -- _optional_, prints this help text
@@ -469,19 +468,19 @@ Invite any user registered on Zapier to test your app. Commonly, this is useful 
 ```bash
 $ zapier invite
 # The invitees on your app listed below.
-
-# ┌───────────────────┬──────────┬──────────┬─────────┐
-# │ Email             │ Role     │ Status   │ Version │
-# ├───────────────────┼──────────┼──────────┼─────────┤
-# │ user@example.com  │ invitees │ accepted │ 1.0.0   │
-# └───────────────────┴──────────┴──────────┴─────────┘
+#
+# ┌──────────────────┬─────────┬──────────┐
+# │ Email            │ Role    │ Status   │
+# ├──────────────────┼─────────┼──────────┤
+# │ user@example.com │ invitee │ accepted │
+# └──────────────────┴─────────┴──────────┘
 #
 # Don't want to send individual invite emails? Use this public link and share with anyone on the web:
 #
 #   https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/
 
-$ zapier invite user@example.com 1.0.0
-# Preparing to add invitee user@example.com to your app "Example (1.0.0)".
+$ zapier invite user@example.com
+# Preparing to add invitee user@example.com to your app "Example".
 #
 #   Adding user@example.com - done!
 #

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -447,12 +447,12 @@ $ zapier init example-app --template=minimal
 
 ## invite
 
-  > Manage the invitees/testers on your project. Can optionally --remove.
+  > Manage the invitees/testers on your project. Can optionally specify a version or --remove.
 
-  **Usage:** `zapier invite [user@example.com]`
+  **Usage:** `zapier invite [user@example.com] [1.0.0]`
 
   
-Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your apps. If you'd like to provide full admin access, try `zapier collaborate`.
+Invite any user registered on Zapier to test your app. Commonly, this is useful for teammates, contractors, or other team members who might want to test, QA, or view your app versions. If you'd like to provide full admin access, try `zapier collaborate`.
 
 > Send an email directly, which contains a one-time use link for them only - or share the public URL to "bulk" invite folks!
 
@@ -460,6 +460,7 @@ Invite any user registered on Zapier to test your app. Commonly, this is useful 
 
 * _none_ -- print all invitees
 * `email [user@example.com]` -- _optional_, which user to add/remove
+* `version [1.0.0]` -- _optional_, only invite to a specific version
 * `--remove` -- _optional_, elect to remove this user
 * `--format={plain,json,raw,row,table,small}` -- _optional_, display format. Default is `table`
 * `--help` -- _optional_, prints this help text
@@ -468,19 +469,19 @@ Invite any user registered on Zapier to test your app. Commonly, this is useful 
 ```bash
 $ zapier invite
 # The invitees on your app listed below.
-#
-# ┌──────────────────┬─────────┬──────────┐
-# │ Email            │ Role    │ Status   │
-# ├──────────────────┼─────────┼──────────┤
-# │ user@example.com │ invitee │ accepted │
-# └──────────────────┴─────────┴──────────┘
+
+# ┌───────────────────┬──────────┬──────────┬─────────┐
+# │ Email             │ Role     │ Status   │ Version │
+# ├───────────────────┼──────────┼──────────┼─────────┤
+# │ user@example.com  │ invitees │ accepted │ 1.0.0   │
+# └───────────────────┴──────────┴──────────┴─────────┘
 #
 # Don't want to send individual invite emails? Use this public link and share with anyone on the web:
 #
 #   https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/
 
-$ zapier invite user@example.com
-# Preparing to add invitee user@example.com to your app "Example".
+$ zapier invite user@example.com 1.0.0
+# Preparing to add invitee user@example.com to your app "Example (1.0.0)".
 #
 #   Adding user@example.com - done!
 #

--- a/docs/index.html
+++ b/docs/index.html
@@ -2886,7 +2886,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <p>To see your <code>z.console</code> logs, do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-bash">zapier logs --type=console
+      <pre><code class="lang-bash">zapier logs --<span class="hljs-built_in">type</span>=console
 </code></pre>
     </div>
   </div>
@@ -2928,7 +2928,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <p>To see the HTTP logs, do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-bash">zapier logs --type=http
+      <pre><code class="lang-bash">zapier logs --<span class="hljs-built_in">type</span>=http
 </code></pre>
     </div>
   </div>
@@ -2938,7 +2938,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <p>To see detailed http logs including headers, request and response bodies, etc, do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-bash">zapier logs --type=http --detailed
+      <pre><code class="lang-bash">zapier logs --<span class="hljs-built_in">type</span>=http --detailed
 </code></pre>
     </div>
   </div>
@@ -3012,7 +3012,7 @@ using this error in cases where a required pre-condition is not met. For instanc
 in a create to add an email address to a list where duplicates are not allowed,
 you would want to throw a <code>HaltedError</code> if the Zap attempted to add a duplicate.
 This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>Error</code>, a Zap will never by turned off when this error is thrown
-(even if it is raised more often than not).</p><p>Example: <code>throw new HaltedError(&apos;Your reason.&apos;);</code></p>
+(even if it is raised more often than not).</p><p>Example: <code>throw z.errors.HaltedError(&apos;Your reason.&apos;);</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3034,9 +3034,9 @@ This would indicate failure, but it would be treated as a soft failure.</p><p>Un
 provides a mechanism to notify users of expired credentials. With the
 <code>ExpiredAuthError</code>, the current operation is interrupted, the Zap is turned off
 (to prevent more calls with expired credentials), and a predefined email is sent
-out informing the user to refresh the credentials.</p><p>Example: <code>throw new ExpiredAuthError(&apos;Your message.&apos;);</code></p><p>For apps that use OAuth2 + refresh or Session Auth, you can use the
+out informing the user to refresh the credentials.</p><p>Example: <code>throw new z.errors.ExpiredAuthError(&apos;Your message.&apos;);</code></p><p>For apps that use OAuth2 + refresh or Session Auth, you can use the
 <code>RefreshAuthError</code>. This will signal Zapier to refresh the credentials and then
-repeat the failed operation.</p><p>Example: <code>throw new RefreshAuthError();</code></p>
+repeat the failed operation.</p><p>Example: <code>throw new z.errors.RefreshAuthError();</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -3012,7 +3012,7 @@ using this error in cases where a required pre-condition is not met. For instanc
 in a create to add an email address to a list where duplicates are not allowed,
 you would want to throw a <code>HaltedError</code> if the Zap attempted to add a duplicate.
 This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>Error</code>, a Zap will never by turned off when this error is thrown
-(even if it is raised more often than not).</p><p>Example: <code>throw z.errors.HaltedError(&apos;Your reason.&apos;);</code></p>
+(even if it is raised more often than not).</p><p>Example: <code>throw new z.errors.HaltedError(&apos;Your reason.&apos;);</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=v6.10.2"
   },
   "scripts": {
-    "docs": "node lib/bin/docs.js",
+    "docs": "npm run build && node lib/bin/docs.js",
     "preversion": "git pull && npm test",
     "version": "npm run docs && npm run gen-completions && git add docs/* goodies/* README.md",
     "postversion": "git push && git push --tags && npm publish",


### PR DESCRIPTION
Readme examples had `throw new HalterError` which should be `throw new z.errors.HaltedError`.