### PR TITLE
Fix noun in `zapier convert`

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -167,11 +167,13 @@ const renderStep = (type, definition, key) => {
     quote(definition.url) + ',' :
     `'http://example.com/api/${key}.json', // TODO this is just an example`;
 
+  const noun = definition.noun || _.capitalize(key);
+
   const templateContext = {
     KEY: snakeCase(key),
     CAMEL: camelCase(key),
-    NOUN: definition.noun,
-    LOWER_NOUN: key.toLowerCase(),
+    NOUN: noun,
+    LOWER_NOUN: noun.toLowerCase(),
     FIELDS: fields.join(',\n'),
     SAMPLE: sample,
     URL: url

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -170,7 +170,7 @@ const renderStep = (type, definition, key) => {
   const templateContext = {
     KEY: snakeCase(key),
     CAMEL: camelCase(key),
-    NOUN: _.capitalize(key),
+    NOUN: definition.noun,
     LOWER_NOUN: key.toLowerCase(),
     FIELDS: fields.join(',\n'),
     SAMPLE: sample,


### PR DESCRIPTION
Fixes https://github.com/zapier/zapier-platform-app-converted-google-maps/blob/32892cf9526b20ac087dd326230bbf2948a2247c/triggers/place_types.js#L25.