### PR TITLE
Skip Style Checks on Invalid apps

### DIFF
--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -72,6 +72,10 @@ const validate = (context) => {
       }
     })
     .then((styleResult) => {
+      if (global.argOpts['without-style']) {
+        return;
+      }
+
       // process errors
       let styleErrors = condenseIssues(styleResult);
       const ifEmpty = colors.grey('No style errors found during validation routine.');
@@ -89,6 +93,7 @@ const validate = (context) => {
       } else {
         context.line('Your app looks great!\n');
       }
+      return;
     });
 };
 validate.argsSpec = [];

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -57,7 +57,13 @@ const validate = (context) => {
       }
     })
     .then(() => {
-      if (!global.argOpts['without-style']) {
+      if (global.argOpts['without-style']) {
+        return Promise.resolve([]);
+      } else if (process.exitCode === 1) {
+        // There were schema errors with the app, meaning Zapier may not be able to parse it
+        context.line(colors.grey('\nSkipping app style check because app did not validate.'));
+        return Promise.resolve([]);
+      } else {
         context.line('\nChecking app style.');
         return utils.localAppCommand({ command: 'definition' })
           .then((rawDefinition) => {
@@ -67,12 +73,10 @@ const validate = (context) => {
               body: rawDefinition
             });
           });
-      } else {
-        return Promise.resolve([]);
       }
     })
     .then((styleResult) => {
-      if (global.argOpts['without-style']) {
+      if (global.argOpts['without-style'] || process.exitCode === 1) {
         return;
       }
 


### PR DESCRIPTION
## Description

If a dev has an app that has major schema validation errors (but still parses as JSON), the `zapier validate` command will POST that to zapier.com to run the style checks. In some cases, this can cause the server to throw a 500. That is being fixed, and will soon correctly return a 403.

However, there really isn't a point in making that call at all if we know locally we are invalid. So, this PR updates the validate command to skip style checks on invalid apps.

## TODO

- [x] Skip style check API call on invalid app
- [x] Do not print success message if style checks are skipped due to invalid app
- [x] Do not print success if `-without-styles` flag is passed.