### PR TITLE
zapier convert: Add tests ensuring default help text

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -140,6 +140,44 @@ describe('convert render functions', () => {
     });
   });
 
+  describe('render step', () => {
+    it('should fill with trigger default description', () => {
+      const v2Def = {
+        key: 'exampleStep',
+        noun: 'Example',
+        label: 'Example Step',
+      };
+
+      return convert.renderStep('trigger', v2Def).then(content => {
+        content.should.containEql("description: 'Triggers on a new example.'");
+      });
+    });
+
+    it('should fill with create default description', () => {
+      const v2Def = {
+        key: 'exampleStep',
+        noun: 'Example',
+        label: 'Example Step',
+      };
+
+      return convert.renderStep('create', v2Def).then(content => {
+        content.should.containEql("description: 'Creates a example.'");
+      });
+    });
+
+    it('should fill with search default description', () => {
+      const v2Def = {
+        key: 'exampleStep',
+        noun: 'Example',
+        label: 'Example Step',
+      };
+
+      return convert.renderStep('search', v2Def).then(content => {
+        content.should.containEql("description: 'Finds a example.'");
+      });
+    });
+  });
+
   describe('render sample', () => {
     it('should render sample output fields', () => {
       const v2Def = {


### PR DESCRIPTION
We already give users a default description/help text for a step when `zapier convert` can't find it in their app definition. This PR adds some tests to ensure that.