### PR TITLE
zapier convert: Fix test code with Promises

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -40,7 +40,7 @@ describe('convert render functions', () => {
   });
 
   describe('authentication', () => {
-    it('should render basic auth', (done) => {
+    it('should render basic auth', () => {
       const v2Def = {
         general: {
           auth_type: 'Basic Auth'
@@ -60,7 +60,7 @@ describe('convert render functions', () => {
         }
       };
 
-      convert.renderAuth(v2Def).then(string => {
+      return convert.renderAuth(v2Def).then(string => {
         const auth = s2js(string);
         auth.should.eql({
           type: 'basic',
@@ -86,11 +86,10 @@ describe('convert render functions', () => {
           ]
         });
       });
-      done();
     });
   });
 
-  it.skip('should render oauth2', (done) => {
+  it.skip('should render oauth2', () => {
     const v2Def = {
       general: {
         auth_type: 'OAuth V2',
@@ -101,7 +100,7 @@ describe('convert render functions', () => {
       }
     };
 
-    convert.renderAuth(v2Def).then(string => {
+    return convert.renderAuth(v2Def).then(string => {
       const auth = s2js(string);
 
       auth.should.eql({
@@ -136,7 +135,6 @@ describe('convert render functions', () => {
           }
         }
       });
-      done();
     });
   });
 


### PR DESCRIPTION
A couple of asynchronous tests in `convert.js` don't get run when you do `npm run test`. For some reasons the `done()` used originally doesn't work. This PR fixes it by returning the Promise for Mocha to pick up. See https://mochajs.org/#working-with-promises for more detail.