### PR TITLE
zapier convert: Handle empty and multi-line field help text

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -39,15 +39,15 @@ describe('convert render functions', () => {
       });
     });
 
-    it('should pad help text that is too short', () => {
+    it('should keep empty help text empty', () => {
       const wbKey = 'test_field';
       const wbDef = {
-        help_text: 'too short'
+        help_text: ''
       };
 
       const string = convert.renderField(wbDef, wbKey);
       const field = s2js(string);
-      field.helpText.should.eql('too short (help text must be at least 10 characters)');
+      field.helpText.should.eql('');
     });
 
     it('should convert a dynamic dropdown', () => {
@@ -97,14 +97,14 @@ describe('convert render functions', () => {
                 type: 'string',
                 required: true,
                 label: 'Username',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               },
               {
                 key: 'password',
                 type: 'password',
                 required: true,
                 label: 'Password',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               }
             ],
             connectionLabel: '{{username}}'
@@ -129,7 +129,7 @@ describe('convert render functions', () => {
                 type: 'string',
                 required: true,
                 label: 'API Key',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               }
             ],
             connectionLabel: '{{user}}'
@@ -172,7 +172,7 @@ describe('convert render functions', () => {
                 type: 'string',
                 required: true,
                 label: 'API Key',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               }
             ],
             connectionLabel: '{{user}}'
@@ -215,14 +215,14 @@ describe('convert render functions', () => {
                 type: 'string',
                 required: true,
                 label: 'Email',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               },
               {
                 key: 'pass',
                 type: 'password',
                 required: true,
                 label: 'Password',
-                helpText: '(help text must be at least 10 characters)'
+                helpText: ''
               }
             ],
             sessionConfig: {

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -47,7 +47,7 @@ describe('convert render functions', () => {
 
       const string = convert.renderField(wbDef, wbKey);
       const field = s2js(string);
-      field.helpText.should.eql('');
+      field.should.not.have.property('helpText');
     });
 
     it('should escape multi-line help text', () => {
@@ -108,15 +108,13 @@ describe('convert render functions', () => {
                 key: 'username',
                 type: 'string',
                 required: true,
-                label: 'Username',
-                helpText: ''
+                label: 'Username'
               },
               {
                 key: 'password',
                 type: 'password',
                 required: true,
-                label: 'Password',
-                helpText: ''
+                label: 'Password'
               }
             ],
             connectionLabel: '{{username}}'
@@ -140,8 +138,7 @@ describe('convert render functions', () => {
                 key: 'api_key',
                 type: 'string',
                 required: true,
-                label: 'API Key',
-                helpText: ''
+                label: 'API Key'
               }
             ],
             connectionLabel: '{{user}}'
@@ -183,8 +180,7 @@ describe('convert render functions', () => {
                 key: 'api_key',
                 type: 'string',
                 required: true,
-                label: 'API Key',
-                helpText: ''
+                label: 'API Key'
               }
             ],
             connectionLabel: '{{user}}'
@@ -226,15 +222,13 @@ describe('convert render functions', () => {
                 key: 'email',
                 type: 'string',
                 required: true,
-                label: 'Email',
-                helpText: ''
+                label: 'Email'
               },
               {
                 key: 'pass',
                 type: 'password',
                 required: true,
-                label: 'Password',
-                helpText: ''
+                label: 'Password'
               }
             ],
             sessionConfig: {

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -50,6 +50,18 @@ describe('convert render functions', () => {
       field.helpText.should.eql('');
     });
 
+    it('should escape multi-line help text', () => {
+      const wbKey = 'test_field';
+      const wbDef = {
+        help_text: 'line 1\nline 2\nline 3\n'
+      };
+
+      const string = convert.renderField(wbDef, wbKey);
+      console.log(string);
+      const field = s2js(string);
+      field.helpText.should.eql('line 1\\nline 2\\nline 3\\n');
+    });
+
     it('should convert a dynamic dropdown', () => {
       const wbKey = 'test';
       const wbDef = {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -95,7 +95,11 @@ const renderField = (definition, key) => {
   if (definition.label) {
     props.push(renderProp('label', quote(definition.label)));
   }
-  props.push(renderProp('helpText', quote(escapeLineBreaks(definition.help_text || ''))));
+
+  if (definition.help_text) {
+    props.push(renderProp('helpText', quote(escapeLineBreaks(definition.help_text))));
+  }
+
   props.push(renderProp('type', quote(type)));
   props.push(renderProp('required', Boolean(definition.required)));
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -4,7 +4,6 @@ const {camelCase, snakeCase} = require('./misc');
 const {readFile, writeFile, ensureDir} = require('./files');
 const {printStarting, printDone} = require('./display');
 
-const MIN_HELP_TEXT_LENGTH = 10;
 const TEMPLATE_DIR = path.join(__dirname, '../../scaffold/convert');
 const ZAPIER_LEGACY_SCRIPTING_RUNNER_VERSION = '1.0.0';
 
@@ -77,17 +76,6 @@ const createFile = (content, fileName, dir) => {
     });
 };
 
-const padHelpText = (text) => {
-  const msg = `(help text must be at least ${MIN_HELP_TEXT_LENGTH} characters)`;
-  if (!_.isString(text)) {
-    return msg;
-  }
-  if (text.length < MIN_HELP_TEXT_LENGTH) {
-    return `${text} ${msg}`;
-  }
-  return text;
-};
-
 const renderProp = (key, value) => `${key}: ${value}`;
 
 const quote = s => `'${s}'`;
@@ -105,7 +93,7 @@ const renderField = (definition, key) => {
   if (definition.label) {
     props.push(renderProp('label', quote(definition.label)));
   }
-  props.push(renderProp('helpText', quote(padHelpText(definition.help_text))));
+  props.push(renderProp('helpText', quote(definition.help_text || '')));
   props.push(renderProp('type', quote(type)));
   props.push(renderProp('required', Boolean(definition.required)));
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -80,6 +80,8 @@ const renderProp = (key, value) => `${key}: ${value}`;
 
 const quote = s => `'${s}'`;
 
+const escapeLineBreaks = s => s.replace(/\n/g, '\\\\n');
+
 const getAuthType = (definition) => {
   return authTypeMap[definition.general.auth_type];
 };
@@ -93,7 +95,7 @@ const renderField = (definition, key) => {
   if (definition.label) {
     props.push(renderProp('label', quote(definition.label)));
   }
-  props.push(renderProp('helpText', quote(definition.help_text || '')));
+  props.push(renderProp('helpText', quote(escapeLineBreaks(definition.help_text || ''))));
   props.push(renderProp('type', quote(type)));
   props.push(renderProp('required', Boolean(definition.required)));
 


### PR DESCRIPTION
Fixes two issues with field help text:

1. Don't pad help text if it's too short. Keep empty help text empty.
2. Escape line breaks in help text so that it doesn't break the template.