### PR TITLE
zapier convert: Escape special chars in field help text

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -57,9 +57,19 @@ describe('convert render functions', () => {
       };
 
       const string = convert.renderField(wbDef, wbKey);
-      console.log(string);
       const field = s2js(string);
-      field.helpText.should.eql('line 1\\nline 2\\nline 3\\n');
+      field.helpText.should.eql('line 1\nline 2\nline 3\n');
+    });
+
+    it('should escape single quotes in help text', () => {
+      const wbKey = 'test_field';
+      const wbDef = {
+        help_text: "That's ok"
+      };
+
+      const string = convert.renderField(wbDef, wbKey);
+      const field = s2js(string);
+      field.helpText.should.eql("That's ok");
     });
 
     it('should convert a dynamic dropdown', () => {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -80,7 +80,7 @@ const renderProp = (key, value) => `${key}: ${value}`;
 
 const quote = s => `'${s}'`;
 
-const escapeLineBreaks = s => s.replace(/\n/g, '\\\\n');
+const escapeSpecialChars = s => s.replace(/\n/g, '\\n').replace(/'/g, "\\'");
 
 const getAuthType = (definition) => {
   return authTypeMap[definition.general.auth_type];
@@ -97,7 +97,7 @@ const renderField = (definition, key) => {
   }
 
   if (definition.help_text) {
-    props.push(renderProp('helpText', quote(escapeLineBreaks(definition.help_text))));
+    props.push(renderProp('helpText', quote(escapeSpecialChars(definition.help_text))));
   }
 
   props.push(renderProp('type', quote(type)));


### PR DESCRIPTION
* Fix redundant slashes when escaping line breaks
* Escape single quotes (')