### PR TITLE
zapier convert: Normalize newlines in scripting

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -500,4 +500,25 @@ const getSessionKey = (z, bundle) => {
     });
   });
 
+  describe('render scripting', () => {
+    it('should normalize newlines', () => {
+      const wbDef = {
+        js: 'var a = 1;\r\nvar b = 2;\rvar c = 3;\n'
+      };
+      return convert.renderScripting(wbDef).then(scripting => {
+        scripting.should.containEql('var a = 1;\nvar b = 2;\nvar c = 3;\n');
+      });
+    });
+
+    it("should remove 'use strict'", () => {
+      const wbDef = {
+        js: "'use strict';\nvar foo = 'bar';\n'"
+      };
+      return convert.renderScripting(wbDef).then(scripting => {
+        scripting.should.not.containEql("'use strict';\nvar foo = 'bar';\n");
+        scripting.should.containEql("var foo = 'bar';\n");
+      });
+    });
+  });
+
 });

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -586,6 +586,9 @@ const renderScripting = (legacyApp) => {
     return Promise.resolve();
   }
 
+  // Normalize newlines to '\n'
+  templateContext.CODE = templateContext.CODE.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
   // Remove any 'use strict'; or "use strict"; since we add that automatically
   templateContext.CODE = templateContext.CODE.replace("'use strict';\n", '').replace('"use strict";\n', '');
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -628,6 +628,7 @@ module.exports = {
   renderAuth,
   renderField,
   renderSample,
+  renderScripting,
   renderStep,
   renderTemplate,
 


### PR DESCRIPTION
This PR normalizes all the newline characters to `\n` if user uses `\r\n` or `\r` as newlines in their JavaScript scripting.