### PR TITLE
Add example docs about computed fields.

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -27,7 +27,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 ### What is an App?
 
 A CLI App is an implementation of your app's API. You build a Node.js application
-that exports a single object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
+that exports a single object ([JSON Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#appschema)) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.
 
@@ -391,7 +391,7 @@ The second is the `noun`, the user-friendly name of the resource that is present
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-resource for a working example app using resources.
 
 After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
-The complete list of available methods can be found in the [Resource Schema Docs](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema).
+The complete list of available methods can be found in the [Resource Schema Docs](https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema).
 For now, let's focus on two:
 
  * `list` - Tells Zapier how to fetch a set of this resource. This becomes a Trigger in the Zapier Editor.
@@ -403,7 +403,7 @@ Here is a complete example of what the list method might look like
 [insert-file:./snippets/recipe-list.js]
 ```
 
-The method is made up of two properties, a `display` and an `operation`. The `display` property ([schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicdisplayschema)) holds the info needed to present the method as an available Trigger in the Zapier Editor. The `operation` ([schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema)) provides the implementation to make the API call.
+The method is made up of two properties, a `display` and an `operation`. The `display` property ([schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema)) holds the info needed to present the method as an available Trigger in the Zapier Editor. The `operation` ([schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema)) provides the implementation to make the API call.
 
 Adding a create method looks very similar.
 
@@ -429,8 +429,8 @@ The definition for each of these follows the same structure. Here is an example 
 [insert-file:./snippets/trigger.js]
 ```
 
-You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#triggerschema),
-[Search Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#createschema).
+You can find more details on the definition for each by looking at the [Trigger Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#triggerschema),
+[Search Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#searchschema), and [Create Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#createschema).
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-trigger for a working example app using triggers.
 
@@ -454,7 +454,7 @@ Each of the 3 types of function expects a certain type of object. As of core `v1
 
 On each trigger, search, or create in the `operation` directive - you can provide an array of objects as fields under the `inputFields`. Fields are what your users would see in the main Zapier user interface. For example, you might have a "create contact" action with fields like "First name", "Last name", "Email", etc.
 
-You can find more details on each and every field option at [Field Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#fieldschema).
+You can find more details on each and every field option at [Field Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema).
 
 Those fields have various options you can provide, here is a succinct example:
 
@@ -508,6 +508,11 @@ For fields that take id of another object to create a relationship between the t
 
 If you don't define a trigger for the `dynamic` property, the search connector won't show.
 
+### Computed Fields
+
+In OAuth and Session Auth, you might want to store fields in `bundle.authData` (other than `access_token`, `refresh_token` — for OAuth —, or `sessionKey` — for Session Auth), that you don't want the user to fill in.
+
+For those situations, you need a computed field. It's just like another field, but with a `computed: true` property (don't forget to also make it `required: false`). You can see examples in the [OAuth](#oauth2) or [Session Auth](#session) example sections.
 
 ## Z Object
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
   * [Custom/Dynamic Fields](#customdynamic-fields)
   * [Dynamic Dropdowns](#dynamic-dropdowns)
   * [Search-Powered Fields](#search-powered-fields)
+  * [Computed Fields](#computed-fields)
 - [Z Object](#z-object)
   * [`z.request([url], options)`](#zrequesturl-options)
   * [`z.console(message)`](#zconsolemessage)
@@ -114,7 +115,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 ### What is an App?
 
 A CLI App is an implementation of your app's API. You build a Node.js application
-that exports a single object ([JSON Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema)) and upload it to Zapier.
+that exports a single object ([JSON Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#appschema)) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.
 
@@ -536,6 +537,11 @@ const authentication = {
   fields: [
     {key: 'username', type: 'string', required: true, helpText: 'Your login username.'},
     {key: 'password', type: 'string', required: true, helpText: 'Your login password.'}
+    // For Session Auth we store `sessionKey` automatically in `bundle.authData`
+    // for future use. If you need to save/use something that the user shouldn't
+    // need to type/choose, add a "computed" field, like:
+    // {key: 'something': type: 'string', required: false, computed: true}
+    // And remember to return it in sessionConfig.perform
   ],
   sessionConfig: {
     perform: getSessionKey
@@ -642,6 +648,11 @@ const authentication = {
   // If you need any fields upfront, put them here
   fields: [
     {key: 'subdomain', type: 'string', required: true, default: 'app'}
+    // For OAuth we store `access_token` and `refresh_token` automatically
+    // in `bundle.authData` for future use. If you need to save/use something
+    // that the user shouldn't need to type/choose, add a "computed" field, like:
+    // {key: 'something': type: 'string', required: false, computed: true}
+    // And remember to return it in oauth2Config.getAccessToken/refreshAccessToken
   ]
 };
 
@@ -708,7 +719,7 @@ The second is the `noun`, the user-friendly name of the resource that is present
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-resource for a working example app using resources.
 
 After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
-The complete list of available methods can be found in the [Resource Schema Docs](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema).
+The complete list of available methods can be found in the [Resource Schema Docs](https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema).
 For now, let's focus on two:
 
  * `list` - Tells Zapier how to fetch a set of this resource. This becomes a Trigger in the Zapier Editor.
@@ -737,7 +748,7 @@ const Recipe = {
 
 ```
 
-The method is made up of two properties, a `display` and an `operation`. The `display` property ([schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicdisplayschema)) holds the info needed to present the method as an available Trigger in the Zapier Editor. The `operation` ([schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema)) provides the implementation to make the API call.
+The method is made up of two properties, a `display` and an `operation`. The `display` property ([schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema)) holds the info needed to present the method as an available Trigger in the Zapier Editor. The `operation` ([schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema)) provides the implementation to make the API call.
 
 Adding a create method looks very similar.
 
@@ -813,8 +824,8 @@ const App = {
 
 ```
 
-You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#triggerschema),
-[Search Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#createschema).
+You can find more details on the definition for each by looking at the [Trigger Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#triggerschema),
+[Search Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#searchschema), and [Create Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#createschema).
 
 > Example App: check out https://github.com/zapier/zapier-platform-example-app-trigger for a working example app using triggers.
 
@@ -838,7 +849,7 @@ Each of the 3 types of function expects a certain type of object. As of core `v1
 
 On each trigger, search, or create in the `operation` directive - you can provide an array of objects as fields under the `inputFields`. Fields are what your users would see in the main Zapier user interface. For example, you might have a "create contact" action with fields like "First name", "Last name", "Email", etc.
 
-You can find more details on each and every field option at [Field Schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#fieldschema).
+You can find more details on each and every field option at [Field Schema](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema).
 
 Those fields have various options you can provide, here is a succinct example:
 
@@ -1007,6 +1018,11 @@ const App = {
 
 If you don't define a trigger for the `dynamic` property, the search connector won't show.
 
+### Computed Fields
+
+In OAuth and Session Auth, you might want to store fields in `bundle.authData` (other than `access_token`, `refresh_token` — for OAuth —, or `sessionKey` — for Session Auth), that you don't want the user to fill in.
+
+For those situations, you need a computed field. It's just like another field, but with a `computed: true` property (don't forget to also make it `required: false`). You can see examples in the [OAuth](#oauth2) or [Session Auth](#session) example sections.
 
 ## Z Object
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -285,6 +285,7 @@ a code {
 <li><a href="#customdynamic-fields">Custom/Dynamic Fields</a></li>
 <li><a href="#dynamic-dropdowns">Dynamic Dropdowns</a></li>
 <li><a href="#search-powered-fields">Search-Powered Fields</a></li>
+<li><a href="#computed-fields">Computed Fields</a></li>
 </ul>
 </li>
 <li><a href="#z-object">Z Object</a><ul>
@@ -455,6 +456,7 @@ a code {
 <li><a href="#customdynamic-fields">Custom/Dynamic Fields</a></li>
 <li><a href="#dynamic-dropdowns">Dynamic Dropdowns</a></li>
 <li><a href="#search-powered-fields">Search-Powered Fields</a></li>
+<li><a href="#computed-fields">Computed Fields</a></li>
 </ul>
 </li>
 <li><a href="#z-object">Z Object</a><ul>
@@ -563,7 +565,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>A CLI App is an implementation of your app&apos;s API. You build a Node.js application
-that exports a single object (<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#appschema">JSON Schema</a>) and upload it to Zapier.
+that exports a single object (<a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#appschema">JSON Schema</a>) and upload it to Zapier.
 Zapier introspects that definition to find out what your app is capable of and
 what options to present end users in the Zap Editor.</p><p>For those not familiar with Zapier terminology, here is how concepts in the CLI
 map to the end user experience:</p><ul>
@@ -1262,6 +1264,11 @@ zapier convert 1234 .
   <span class="hljs-attr">fields</span>: [
     {<span class="hljs-attr">key</span>: <span class="hljs-string">&apos;username&apos;</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>, <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Your login username.&apos;</span>},
     {<span class="hljs-attr">key</span>: <span class="hljs-string">&apos;password&apos;</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>, <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Your login password.&apos;</span>}
+    <span class="hljs-comment">// For Session Auth we store `sessionKey` automatically in `bundle.authData`</span>
+    <span class="hljs-comment">// for future use. If you need to save/use something that the user shouldn&apos;t</span>
+    <span class="hljs-comment">// need to type/choose, add a &quot;computed&quot; field, like:</span>
+    <span class="hljs-comment">// {key: &apos;something&apos;: type: &apos;string&apos;, required: false, computed: true}</span>
+    <span class="hljs-comment">// And remember to return it in sessionConfig.perform</span>
   ],
   <span class="hljs-attr">sessionConfig</span>: {
     <span class="hljs-attr">perform</span>: getSessionKey
@@ -1387,6 +1394,11 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
   <span class="hljs-comment">// If you need any fields upfront, put them here</span>
   fields: [
     {<span class="hljs-attr">key</span>: <span class="hljs-string">&apos;subdomain&apos;</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>, <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">default</span>: <span class="hljs-string">&apos;app&apos;</span>}
+    <span class="hljs-comment">// For OAuth we store `access_token` and `refresh_token` automatically</span>
+    <span class="hljs-comment">// in `bundle.authData` for future use. If you need to save/use something</span>
+    <span class="hljs-comment">// that the user shouldn&apos;t need to type/choose, add a &quot;computed&quot; field, like:</span>
+    <span class="hljs-comment">// {key: &apos;something&apos;: type: &apos;string&apos;, required: false, computed: true}</span>
+    <span class="hljs-comment">// And remember to return it in oauth2Config.getAccessToken/refreshAccessToken</span>
   ]
 };
 
@@ -1489,7 +1501,7 @@ read, and search operations on that resource.</p>
 The second is the <code>noun</code>, the user-friendly name of the resource that is presented to users throughout the Zapier UI.</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-resource">https://github.com/zapier/zapier-platform-example-app-resource</a> for a working example app using resources.</p>
 </blockquote><p>After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
-The complete list of available methods can be found in the <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema">Resource Schema Docs</a>.
+The complete list of available methods can be found in the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema">Resource Schema Docs</a>.
 For now, let&apos;s focus on two:</p><ul>
 <li><code>list</code> - Tells Zapier how to fetch a set of this resource. This becomes a Trigger in the Zapier Editor.</li>
 <li><code>create</code> - Tells Zapier how to create a new instance of the resource. This becomes an Action in the Zapier Editor.</li>
@@ -1519,7 +1531,7 @@ For now, let&apos;s focus on two:</p><ul>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The method is made up of two properties, a <code>display</code> and an <code>operation</code>. The <code>display</code> property (<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicdisplayschema">schema</a>) holds the info needed to present the method as an available Trigger in the Zapier Editor. The <code>operation</code> (<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#resourceschema">schema</a>) provides the implementation to make the API call.</p><p>Adding a create method looks very similar.</p>
+      <p>The method is made up of two properties, a <code>display</code> and an <code>operation</code>. The <code>display</code> property (<a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#basicdisplayschema">schema</a>) holds the info needed to present the method as an available Trigger in the Zapier Editor. The <code>operation</code> (<a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#resourceschema">schema</a>) provides the implementation to make the API call.</p><p>Adding a create method looks very similar.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> createRecipeRequest = {
@@ -1608,8 +1620,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You can find more details on the definition for each by looking at the <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#triggerschema">Trigger Schema</a>,
-<a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#searchschema">Search Schema</a>, and <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#createschema">Create Schema</a>.</p><blockquote>
+      <p>You can find more details on the definition for each by looking at the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#triggerschema">Trigger Schema</a>,
+<a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#searchschema">Search Schema</a>, and <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#createschema">Create Schema</a>.</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-trigger">https://github.com/zapier/zapier-platform-example-app-trigger</a> for a working example app using triggers.</p>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-rest-hooks">https://github.com/zapier/zapier-platform-example-app-rest-hooks</a> for a working example app using REST hook triggers.</p>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-search">https://github.com/zapier/zapier-platform-example-app-search</a> for a working example app using searches.</p>
@@ -1684,7 +1696,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>On each trigger, search, or create in the <code>operation</code> directive - you can provide an array of objects as fields under the <code>inputFields</code>. Fields are what your users would see in the main Zapier user interface. For example, you might have a &quot;create contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc.</p><p>You can find more details on each and every field option at <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#fieldschema">Field Schema</a>.</p><p>Those fields have various options you can provide, here is a succinct example:</p>
+      <p>On each trigger, search, or create in the <code>operation</code> directive - you can provide an array of objects as fields under the <code>inputFields</code>. Fields are what your users would see in the main Zapier user interface. For example, you might have a &quot;create contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc.</p><p>You can find more details on each and every field option at <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema">Field Schema</a>.</p><p>Those fields have various options you can provide, here is a succinct example:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> App = {
@@ -1885,6 +1897,24 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><strong>NOTE:</strong> This has to be combined with the <code>dynamic</code> property to give the user a guided experience when setting up a Zap.</p><p>If you don&apos;t define a trigger for the <code>dynamic</code> property, the search connector won&apos;t show.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="computed-fields">Computed Fields</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In OAuth and Session Auth, you might want to store fields in <code>bundle.authData</code> (other than <code>access_token</code>, <code>refresh_token</code> &#x2014; for OAuth &#x2014;, or <code>sessionKey</code> &#x2014; for Session Auth), that you don&apos;t want the user to fill in.</p><p>For those situations, you need a computed field. It&apos;s just like another field, but with a <code>computed: true</code> property (don&apos;t forget to also make it <code>required: false</code>). You can see examples in the <a href="#oauth2">OAuth</a> or <a href="#session">Session Auth</a> example sections.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -58,8 +58,8 @@ const getSessionKey = (z, bundle) => {
   return legacyScriptingRunner.runEvent(getSessionEvent, z, bundle)
     .then((getSessionResult) => {
       // IMPORTANT NOTE:
-      //   WB apps in scripting's get_session_info() allowed to return any object and that would be
-      //   added to the authData, but CLI apps require you to specifically define those.
+      //   WB apps in scripting's get_session_info() allowed you to return any object and that would
+      //   be added to the authData, but CLI apps require you to specifically define those.
       //   That means that if you return more than one key from your scripting's get_session_info(),
       //   you might need to manually tweak this method to return that value at the end of this method,
       //   and also add more fields to the authentication definition.

--- a/snippets/oauth2.js
+++ b/snippets/oauth2.js
@@ -37,6 +37,11 @@ const authentication = {
   // If you need any fields upfront, put them here
   fields: [
     {key: 'subdomain', type: 'string', required: true, default: 'app'}
+    // For OAuth we store `access_token` and `refresh_token` automatically
+    // in `bundle.authData` for future use. If you need to save/use something
+    // that the user shouldn't need to type/choose, add a "computed" field, like:
+    // {key: 'something': type: 'string', required: false, computed: true}
+    // And remember to return it in oauth2Config.getAccessToken/refreshAccessToken
   ]
 };
 

--- a/snippets/session-auth.js
+++ b/snippets/session-auth.js
@@ -27,6 +27,11 @@ const authentication = {
   fields: [
     {key: 'username', type: 'string', required: true, helpText: 'Your login username.'},
     {key: 'password', type: 'string', required: true, helpText: 'Your login password.'}
+    // For Session Auth we store `sessionKey` automatically in `bundle.authData`
+    // for future use. If you need to save/use something that the user shouldn't
+    // need to type/choose, add a "computed" field, like:
+    // {key: 'something': type: 'string', required: false, computed: true}
+    // And remember to return it in sessionConfig.perform
   ],
   sessionConfig: {
     perform: getSessionKey

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -283,8 +283,8 @@ const getSessionKey = (z, bundle) => {
   return legacyScriptingRunner.runEvent(getSessionEvent, z, bundle)
     .then((getSessionResult) => {
       // IMPORTANT NOTE:
-      //   WB apps in scripting's get_session_info() allowed to return any object and that would be
-      //   added to the authData, but CLI apps require you to specifically define those.
+      //   WB apps in scripting's get_session_info() allowed you to return any object and that would
+      //   be added to the authData, but CLI apps require you to specifically define those.
       //   That means that if you return more than one key from your scripting's get_session_info(),
       //   you might need to manually tweak this method to return that value at the end of this method,
       //   and also add more fields to the authentication definition.


### PR DESCRIPTION
Fixes #138

Also moves the schema URLs to proper built docs and fixes a typo in a scaffold comment.

Note this should only be merged after https://github.com/zapier/zapier/pull/14305 is deployed.