### PR TITLE
Improve first promote message.

### DIFF
--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -1,3 +1,4 @@
+const colors = require('colors/safe');
 const utils = require('../utils');
 
 const promote = (context, version) => {
@@ -6,21 +7,34 @@ const promote = (context, version) => {
     return Promise.resolve();
   }
 
+  let appId = 0;
+
   return utils.checkCredentials()
     .then(() => utils.getLinkedApp())
     .then((app) => {
       context.line(`Preparing to promote version ${version} your app "${app.title}".\n`);
       const url = `/apps/${app.id}/versions/${version}/promote/production`;
+      appId = app.id;
       utils.printStarting(`Promoting ${version}`);
       return utils.callAPI(url, {
         method: 'PUT',
         body: {}
-      });
+      }, false);
     })
     .then(() => {
       utils.printDone();
       context.line('  Promotion successful!\n');
       context.line('Optionally try the `zapier migrate 1.0.0 1.0.1 [10%]` command to move users to this version.');
+    })
+    .catch((error) => {
+      // The server 403's when the app hasn't been approved yet
+      if (error.message.indexOf('You cannot promote until we have approved your app.') !== -1) {
+        utils.printDone();
+        context.line('\nGood news! Your app passes validation and has the required number of testers and active Zaps.\n');
+        context.line(`The next step is to visit: ${colors.cyan(`https://zapier.com/developer/builder/cli-app/${appId}/activate/${version}`)} to request public activation of your app.\n`);
+      } else {
+        throw error;
+      }
     });
 };
 promote.argsSpec = [

--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -12,7 +12,7 @@ const promote = (context, version) => {
   return utils.checkCredentials()
     .then(() => utils.getLinkedApp())
     .then((app) => {
-      context.line(`Preparing to promote version ${version} your app "${app.title}".\n`);
+      context.line(`Preparing to promote version ${version} of your app "${app.title}".\n`);
       const url = `/apps/${app.id}/versions/${version}/promote/production`;
       appId = app.id;
       utils.printStarting(`Promoting ${version}`);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -46,7 +46,7 @@ const readCredentials = (credentials, explodeIfMissing = true) => {
 };
 
 // Calls the underlying platform REST API with proper authentication.
-const callAPI = (route, options) => {
+const callAPI = (route, options, displayError = true) => {
   options = options || {};
   const url = options.url || constants.ENDPOINT + route;
 
@@ -101,7 +101,7 @@ const callAPI = (route, options) => {
         }
         console.log(`<< ${res.status}`);
         console.log(`<< ${(text || '').substring(0, 2500)}\n`);
-      } else if (hitError) {
+      } else if (hitError && displayError) {
         printDone(false);
       }
 


### PR DESCRIPTION
Basically instead of being an error, make it show successfully and make the next step more clear.

[Trello Card](https://trello.com/c/wxNvQyUh/215-improve-message-on-promote-when-app-has-not-been-submitted-for-review-yet)

How it looks now:

<img width="1072" alt="screen shot 2017-11-24 at 14 38 44" src="https://user-images.githubusercontent.com/1239616/33214854-7d813be0-d125-11e7-97b3-9838d4f50d61.png">

Meanwhile I've fixed the typo you see above (`1.00 your app` vs `1.0.0 of your app`).