### PR TITLE
fix "should is not a function" bug on test run

### DIFF
--- a/scaffold/convert/create-test.template.js
+++ b/scaffold/convert/create-test.template.js
@@ -1,4 +1,4 @@
-require('should');
+const should = require('should');
 
 const zapier = require('zapier-platform-core');
 

--- a/scaffold/convert/search-test.template.js
+++ b/scaffold/convert/search-test.template.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 
 const zapier = require('zapier-platform-core');
 

--- a/scaffold/convert/search-test.template.js
+++ b/scaffold/convert/search-test.template.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 
 const zapier = require('zapier-platform-core');
 

--- a/scaffold/convert/trigger-test.template.js
+++ b/scaffold/convert/trigger-test.template.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 
 const zapier = require('zapier-platform-core');
 

--- a/scaffold/convert/trigger-test.template.js
+++ b/scaffold/convert/trigger-test.template.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 
 const zapier = require('zapier-platform-core');
 

--- a/snippets/mocha-test.js
+++ b/snippets/mocha-test.js
@@ -1,5 +1,5 @@
 // we use should assertions
-const should = const should = require('should');
+const should = require('should');
 const zapier = require('zapier-platform-core');
 
 // createAppTester() makes it easier to test your app. It takes your

--- a/snippets/mocha-test.js
+++ b/snippets/mocha-test.js
@@ -1,5 +1,5 @@
 // we use should assertions
-const should = require('should');
+const should = const = require('should');
 const zapier = require('zapier-platform-core');
 
 // createAppTester() makes it easier to test your app. It takes your

--- a/snippets/mocha-test.js
+++ b/snippets/mocha-test.js
@@ -1,5 +1,5 @@
 // we use should assertions
-const should = const = require('should');
+const should = const should = require('should');
 const zapier = require('zapier-platform-core');
 
 // createAppTester() makes it easier to test your app. It takes your

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 
 require('../entry'); // must import me to babel polyfill!
 

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,4 +1,4 @@
-const should = require('should');
+require('should'); // says should isn't been used when asserted, yet errors out when it's deleted.
 
 require('../entry'); // must import me to babel polyfill!
 

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 
 require('../entry'); // must import me to babel polyfill!
 

--- a/src/tests/utils/args.js
+++ b/src/tests/utils/args.js
@@ -1,5 +1,3 @@
-const should = require('should');
-
 require('../../entry'); // must import me to babel polyfill!
 
 const argUtils = require('../../utils/args');

--- a/src/tests/utils/args.js
+++ b/src/tests/utils/args.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 
 require('../../entry'); // must import me to babel polyfill!
 

--- a/src/tests/utils/args.js
+++ b/src/tests/utils/args.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 
 require('../../entry'); // must import me to babel polyfill!
 

--- a/src/tests/utils/build.js
+++ b/src/tests/utils/build.js
@@ -1,5 +1,3 @@
-const should = require('should');
-
 const path = require('path');
 
 const build = require('../../utils/build');

--- a/src/tests/utils/build.js
+++ b/src/tests/utils/build.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 
 const path = require('path');
 

--- a/src/tests/utils/build.js
+++ b/src/tests/utils/build.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 
 const path = require('path');
 

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 const convert = require('../../utils/convert');
 const definitions = {
   basic: require('./definitions/basic.json'),

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const convert = require('../../utils/convert');
 const definitions = {
   basic: require('./definitions/basic.json'),

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 const convert = require('../../utils/convert');
 const definitions = {
   basic: require('./definitions/basic.json'),

--- a/src/tests/utils/files.js
+++ b/src/tests/utils/files.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 const files = require('../../utils/files');
 
 const path = require('path');

--- a/src/tests/utils/files.js
+++ b/src/tests/utils/files.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 const files = require('../../utils/files');
 
 const path = require('path');

--- a/src/tests/utils/files.js
+++ b/src/tests/utils/files.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const files = require('../../utils/files');
 
 const path = require('path');

--- a/src/tests/utils/misc.js
+++ b/src/tests/utils/misc.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 const misc = require('../../utils/misc');
 
 describe('misc utils', () => {

--- a/src/tests/utils/misc.js
+++ b/src/tests/utils/misc.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 const misc = require('../../utils/misc');
 
 describe('misc utils', () => {

--- a/src/tests/utils/misc.js
+++ b/src/tests/utils/misc.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const misc = require('../../utils/misc');
 
 describe('misc utils', () => {

--- a/src/tests/utils/promisify.js
+++ b/src/tests/utils/promisify.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const {promisify, promisifyAll} = require('../../utils/promisify');
 
 describe('promisify', () => {

--- a/src/tests/utils/promisify.js
+++ b/src/tests/utils/promisify.js
@@ -1,4 +1,4 @@
-require('should');
+const = require('should');
 const {promisify, promisifyAll} = require('../../utils/promisify');
 
 describe('promisify', () => {

--- a/src/tests/utils/promisify.js
+++ b/src/tests/utils/promisify.js
@@ -1,4 +1,4 @@
-const = require('should');
+const should = require('should');
 const {promisify, promisifyAll} = require('../../utils/promisify');
 
 describe('promisify', () => {


### PR DESCRIPTION
When creating an app with the cli via `zapier init example-app`, a test file is created, ie. `test/index.js`. If a user testing out the cli doesn't manually change `require('should');` to `const should = require('should')` it will cause an error when running `zapier test`, ie. `should is not a function`. Actually even in the docs(https://zapier.com/developer/documentation/v2/getting-started-cli/) it creates a `const` for this.
