### PR TITLE
Allow reading from a changelog for app promotion.

### DIFF
--- a/src/tests/utils/changelog.js
+++ b/src/tests/utils/changelog.js
@@ -1,0 +1,31 @@
+require('should');
+const changelog = require('../../utils/changelog');
+
+describe('changelog utils', () => {
+
+  describe('getVersionChangelog', () => {
+
+    it('should find changelog for 1.0.0', () =>
+      changelog.getVersionChangelog('1.0.0')
+        .then((log) => {
+          log.should.eql('* Removing beta "label".\n* Minor docs fixes.');
+        })
+    );
+
+    it('should not find changelog for 2.3.0', () =>
+      changelog.getVersionChangelog('2.3.0')
+        .then((log) => {
+          log.should.eql('');
+        })
+    );
+
+    it('should not fail when there is no changelog file', () =>
+      changelog.getVersionChangelog('1.0.0', './unexistent-directory')
+        .then((log) => {
+          log.should.eql('');
+        })
+    );
+
+  });
+
+});

--- a/src/utils/changelog.js
+++ b/src/utils/changelog.js
@@ -1,0 +1,42 @@
+const _ = require('lodash');
+const path = require('path');
+
+const { readFile } = require('./files');
+
+const getChangelogFromMarkdown = (version, markdown) => {
+  const lines = markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+
+  let startingLine = _.findIndex(lines, (line) => (line.indexOf(`## ${version}`) === 0));
+
+  if (startingLine === -1) {
+    return '';
+  }
+
+  // Skip the line with the version, and the next line (expected blank)
+  startingLine += 2;
+
+  let endingLine = _.findIndex(lines, (line) => (line.indexOf('## ') === 0), startingLine);
+
+  if (endingLine === -1) {
+    endingLine = lines.length;
+  }
+
+  // Skip the line before the next version (expected blank)
+  endingLine -= 1;
+
+  const changelogLines = lines.slice(startingLine, endingLine);
+
+  return changelogLines.join('\n');
+};
+
+const getVersionChangelog = (version, appDir = '.') => {
+  const file = path.resolve(appDir, 'CHANGELOG.md');
+
+  return readFile(file)
+    .then((buffer) => getChangelogFromMarkdown(version, buffer.toString()))
+    .catch(() => '');// We're ignoring files that don't exist or that aren't readable
+};
+
+module.exports = {
+  getVersionChangelog,
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ module.exports = _.extend(
   require('./api'),
   require('./args'),
   require('./build'),
+  require('./changelog'),
   require('./context'),
   require('./convert'),
   require('./correct-version'),


### PR DESCRIPTION
Also adds tests.

[Relevant Trello Card](https://trello.com/c/vkFrD99V/148-require-allow-cli-developers-to-enter-a-change-message-when-promoting-a-version-to-production)

Cannot be merged until this ships, to support it in the backend: https://github.com/zapier/zapier/pull/14480

No changelog:
<img width="1436" alt="screen shot 2017-11-28 at 15 43 59" src="https://user-images.githubusercontent.com/1239616/33330439-c64b63ee-d456-11e7-8c77-c57c33baa624.png">

With changelog:
<img width="1428" alt="screen shot 2017-11-28 at 15 44 59" src="https://user-images.githubusercontent.com/1239616/33330450-cd547004-d456-11e7-9ec2-2f45298da9ee.png">

(now it asks for confirmation before continuing with or without the changelog)