### PR TITLE
Adding explanation about uppercase env vars

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -695,6 +695,8 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
+> **NOTE** Variables defined via `zapier env` will _always_ be stored and accessed in uppercase format.
+
 
 ### Accessing Environment Variables
 

--- a/README-source.md
+++ b/README-source.md
@@ -695,7 +695,7 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
-> **NOTE** Variables defined via `zapier env` will _always_ be stored and accessed in uppercase format.
+> **NOTE** Variables defined via `zapier env` will _always_ be uppercased. For example, you would access the variable defined by `zapier env 1.0.0 foo_bar 1234` with `process.env.FOO_BAR`.
 
 
 ### Accessing Environment Variables

--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,8 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
+> **NOTE** Variables defined via `zapier env` will _always_ be stored and accessed in uppercase format.
+
 
 ### Accessing Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
-> **NOTE** Variables defined via `zapier env` will _always_ be stored and accessed in uppercase format.
+> **NOTE** Variables defined via `zapier env` will _always_ be uppercased. For example, you would access the variable defined by `zapier env 1.0.0 foo_bar 1234` with `process.env.FOO_BAR`.
 
 
 ### Accessing Environment Variables

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1074,7 +1074,11 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http --detailed --format
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">$ zapier promote 1.0.0
-<span class="hljs-comment"># Preparing to promote version 1.0.0 your app &quot;Example&quot;.</span>
+<span class="hljs-comment"># Preparing to promote version 1.0.0 of your app &quot;Example&quot;.</span>
+* Changelog found <span class="hljs-keyword">for</span> 1.0.0!
+* ---
+* Initial release!
+* ---
 <span class="hljs-comment">#</span>
 <span class="hljs-comment">#   Promoting 1.0.0 - done!</span>
 <span class="hljs-comment">#   Promotion successful!</span>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -601,7 +601,7 @@ $ zapier collaborate user@example.com --remove
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Read and write environment variables.</p>
+<p>Read, write, and delete environment variables.</p>
 </blockquote><p>  <strong>Usage:</strong> <code>zapier env 1.0.0 CLIENT_SECRET 12345</code></p><p>Manage the environment of your app so that <code>process.env</code> has the necessary variables, making it easy to match a local environment with a production environment via <code>CLIENT_SECRET=12345 zapier test</code>.</p><p><strong>Arguments</strong></p><ul>
 <li><code>version [1.0.0]</code> -- <strong>required</strong>, the app version&apos;s environment to work on</li>
 <li><code>key [CLIENT_SECRET]</code> -- <em>optional</em>, the uppercase key of the environment variable to set</li>
@@ -1029,10 +1029,12 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http --detailed --format
 <p>Migrate users from one version of your app to another.</p>
 </blockquote><p>  <strong>Usage:</strong> <code>zapier migrate 1.0.0 1.0.1 [10%]</code></p><p>Starts a migration to move users between different versions of your app. You may also &quot;revert&quot; by simply swapping the from/to verion strings in the command line arguments (IE: <code>zapier migrate 1.0.1 1.0.0</code>).</p><p>Only migrate users between non-breaking versions, use <code>zapier deprecate</code> if you have breaking changes!</p><p>Migrations can take between 5-10 minutes, so be patient and check <code>zapier history</code> to track the status</p><p>Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.</p><blockquote>
 <p>Tip! We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.</p>
+<p>Tip 2! You can migrate a single user by using <code>--user</code> (IE: <code>zapier migrate 1.0.0 1.0.1 --user=user@example.com</code>).</p>
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><code>fromVersion [1.0.0]</code> -- <strong>required</strong>, the version <strong>from</strong> which to migrate users</li>
 <li><code>toVersion [1.0.1]</code> -- <strong>required</strong>, the version <strong>to</strong> which to migrate users</li>
 <li><code>percent [100%]</code> -- <em>optional</em>, percent of users to migrate. Default is <code>100%</code></li>
+<li><code>--user=user@example.com</code> -- <em>optional</em>, migrate only this user</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -276,7 +276,7 @@ $ zapier describe
 
 ## env
 
-  > Read and write environment variables.
+  > Read, write, and delete environment variables.
 
   **Usage:** `zapier env 1.0.0 CLIENT_SECRET 12345`
 
@@ -680,12 +680,14 @@ Note: since a migration is only for non-breaking changes, users are not emailed 
 
 > Tip! We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.
 
+> Tip 2! You can migrate a single user by using `--user` (IE: `zapier migrate 1.0.0 1.0.1 --user=user@example.com`).
+
 **Arguments**
 
 * `fromVersion [1.0.0]` -- **required**, the version **from** which to migrate users
 * `toVersion [1.0.1]` -- **required**, the version **to** which to migrate users
 * `percent [100%]` -- _optional_, percent of users to migrate. Default is `100%`
-
+* `--user=user@example.com` -- _optional_, migrate only this user
 
 ```bash
 $ zapier migrate 1.0.0 1.0.1 15%

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -724,7 +724,11 @@ Promotes are an inherently safe operation for all existing users of your app.
 
 ```bash
 $ zapier promote 1.0.0
-# Preparing to promote version 1.0.0 your app "Example".
+# Preparing to promote version 1.0.0 of your app "Example".
+* Changelog found for 1.0.0!
+* ---
+* Initial release!
+* ---
 #
 #   Promoting 1.0.0 - done!
 #   Promotion successful!

--- a/docs/index.html
+++ b/docs/index.html
@@ -2311,7 +2311,7 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>This is a popular way to provide <code>process.env.ACCESS_TOKEN || bundle.authData.access_token</code> for convenient testing.</p>
-<p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be stored and accessed in uppercase format.</p>
+<p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env 1.0.0 foo_bar 1234</code> with <code>process.env.FOO_BAR</code>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2311,6 +2311,7 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>This is a popular way to provide <code>process.env.ACCESS_TOKEN || bundle.authData.access_token</code> for convenient testing.</p>
+<p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be stored and accessed in uppercase format.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">


### PR DESCRIPTION
For when they're set with `zapier env`.

[Relevant Trello Card](https://trello.com/c/Z6qXyRtT/202-suggestions-for-improvements-to-cli)