### PR TITLE
zapier convert: Add custom input field support

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -216,7 +216,7 @@ module.exports = {
 
   operation: {
     inputFields: [
-<%= FIELDS %><% if (hasCustomInputFields) { %>,
+<%= FIELDS %><% if (hasCustomInputFields) { %><% if (FIELDS) { %>,<% } %>
       getInputFields<% } %>
     ],
 <%= SAMPLE %>

--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -1,7 +1,15 @@
 // "Create" stub created by 'zapier convert'. This is just a stub - you will need to edit!
+const _ = require('lodash');
+
+// Does string replacement ala WB, using bundle and a potential result object
+const replaceVars = (templateString, bundle, result) => {
+  _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+  const values = _.extend({}, bundle.authData, bundle.inputData, result);
+  return _.template(templateString)(values);
+};
 <%
 // Template for just _pre_write()
-if (scripting && preScripting && !postScripting && !fullScripting) { %>
+if (preScripting && !postScripting && !fullScripting) { %>
 const makeRequest = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
@@ -21,7 +29,7 @@ const makeRequest = (z, bundle) => {
 }
 
 // Template for _pre_write() + _post_write()
-if (scripting && preScripting && postScripting && !fullScripting) { %>
+if (preScripting && postScripting && !fullScripting) { %>
 const makeRequest = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
@@ -49,7 +57,7 @@ const makeRequest = (z, bundle) => {
 }
 
 // Template for just _post_write()
-if (scripting && !preScripting && postScripting && !fullScripting) { %>
+if (!preScripting && postScripting && !fullScripting) { %>
 const makeRequest = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
@@ -74,7 +82,7 @@ const makeRequest = (z, bundle) => {
 }
 
 // Template for just _write()
-if (scripting && fullScripting) { %>
+if (fullScripting) { %>
 const makeRequest = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
@@ -92,7 +100,7 @@ const makeRequest = (z, bundle) => {
 }
 
 // If there's no scripting, it's even sweeter and simpler!
-if (!scripting) { %>
+if (!preScripting && !postScripting && !fullScripting) { %>
 const makeRequest = (z, bundle) => {
   const responsePromise = z.request({
     url: '<%= URL %>',
@@ -102,8 +110,99 @@ const makeRequest = (z, bundle) => {
   return responsePromise
     .then(response => z.JSON.parse(response.content));
 };
-<% } %>
+<% }
 
+if (inputFieldFullScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _custom_action_fields() from scripting.
+  const fullFieldsEvent = {
+    name: 'create.input',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+};
+<% } else if (inputFieldPreScripting && !inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _pre_custom_action_fields() from scripting.
+  const preFieldsEvent = {
+    name: 'create.input.pre',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
+    .then((preFieldsResult) => z.request(preFieldsResult))
+    .then((response) => z.JSON.parse(response.content));
+};
+<% } else if (inputFieldPreScripting && inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _pre_custom_action_fields() from scripting.
+  const preFieldsEvent = {
+    name: 'create.input.pre',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
+    .then((preFieldsResult) => z.request(preFieldsResult))
+    .then((response) => {
+      // Do a _post_custom_action_fields() from scripting.
+      const postFieldsEvent = {
+        name: 'create.input.post',
+        key: '<%= KEY %>',
+        response,
+      };
+      return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
+    });
+};
+<% } else if (!inputFieldPreScripting && inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  const responsePromise = z.request({
+    url: bundle._legacyUrl
+  });
+  return responsePromise
+    .then((response) => {
+      // Do a _post_custom_action_fields() from scripting.
+      const postFieldsEvent = {
+        name: 'create.input.post',
+        key: '<%= KEY %>',
+        response,
+      };
+      return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
+    });
+};
+<% } else if (hasCustomInputFields) { %>
+const getInputFields = (z, bundle) => {
+  let url = '<%= CUSTOM_FIELDS_URL %>';
+  url = replaceVars(url, bundle, {});
+
+  const responsePromise = z.request({
+    url: url
+  });
+  return responsePromise
+    .then((response) => z.JSON.parse(response.content));
+};
+<% } %>
 module.exports = {
   key: '<%= KEY %>',
   noun: '<%= NOUN %>',
@@ -117,7 +216,8 @@ module.exports = {
 
   operation: {
     inputFields: [
-<%= FIELDS %>
+<%= FIELDS %><% if (hasCustomInputFields) { %>,
+      getInputFields<% } %>
     ],
 <%= SAMPLE %>
     perform: makeRequest

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -786,6 +786,98 @@ const getList = (z, bundle) => {
     });
 <% } %>
 };
+<% }
+
+if (inputFieldFullScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _custom_action_fields() from scripting.
+  const fullFieldsEvent = {
+    name: 'create.input',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+};
+<% } else if (inputFieldPreScripting && !inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _pre_custom_action_fields() from scripting.
+  const preFieldsEvent = {
+    name: 'create.input.pre',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
+    .then((preFieldsResult) => z.request(preFieldsResult))
+    .then((response) => z.JSON.parse(response.content));
+};
+<% } else if (inputFieldPreScripting && inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  // Do a _pre_custom_action_fields() from scripting.
+  const preFieldsEvent = {
+    name: 'create.input.pre',
+    key: '<%= KEY %>'
+  };
+  return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
+    .then((preFieldsResult) => z.request(preFieldsResult))
+    .then((response) => {
+      // Do a _post_custom_action_fields() from scripting.
+      const postFieldsEvent = {
+        name: 'create.input.post',
+        key: '<%= KEY %>',
+        response,
+      };
+      return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
+    });
+};
+<% } else if (!inputFieldPreScripting && inputFieldPostScripting) { %>
+const getInputFields = (z, bundle) => {
+  const scripting = require('../scripting');
+  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
+
+  bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+
+  const responsePromise = z.request({
+    url: bundle._legacyUrl
+  });
+  return responsePromise
+    .then((response) => {
+      // Do a _post_custom_action_fields() from scripting.
+      const postFieldsEvent = {
+        name: 'create.input.post',
+        key: '<%= KEY %>',
+        response,
+      };
+      return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
+    });
+};
+<% } else if (hasCustomInputFields) { %>
+const getInputFields = (z, bundle) => {
+  let url = '<%= CUSTOM_FIELDS_URL %>';
+  url = replaceVars(url, bundle, {});
+
+  const responsePromise = z.request({
+    url: url
+  });
+  return responsePromise
+    .then((response) => z.JSON.parse(response.content));
+};
 <% } %>
 
 module.exports = {
@@ -801,7 +893,8 @@ module.exports = {
 
   operation: {
     inputFields: [
-<%= FIELDS %>
+      <%= FIELDS %><% if (hasCustomInputFields) { %><% if (FIELDS) { %>,<% } %>
+      getInputFields<% } %>
     ],
 <%= SAMPLE %>
     perform: getList

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -796,9 +796,9 @@ const getInputFields = (z, bundle) => {
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
 
-  // Do a _custom_action_fields() from scripting.
+  // Do a _custom_search_fields() from scripting.
   const fullFieldsEvent = {
-    name: 'create.input',
+    name: 'search.input',
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
@@ -811,9 +811,9 @@ const getInputFields = (z, bundle) => {
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
 
-  // Do a _pre_custom_action_fields() from scripting.
+  // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
-    name: 'create.input.pre',
+    name: 'search.input.pre',
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
@@ -828,17 +828,17 @@ const getInputFields = (z, bundle) => {
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
 
-  // Do a _pre_custom_action_fields() from scripting.
+  // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
-    name: 'create.input.pre',
+    name: 'search.input.pre',
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
     .then((preFieldsResult) => z.request(preFieldsResult))
     .then((response) => {
-      // Do a _post_custom_action_fields() from scripting.
+      // Do a _post_custom_search_fields() from scripting.
       const postFieldsEvent = {
-        name: 'create.input.post',
+        name: 'search.input.post',
         key: '<%= KEY %>',
         response,
       };
@@ -858,9 +858,9 @@ const getInputFields = (z, bundle) => {
   });
   return responsePromise
     .then((response) => {
-      // Do a _post_custom_action_fields() from scripting.
+      // Do a _post_custom_search_fields() from scripting.
       const postFieldsEvent = {
-        name: 'create.input.post',
+        name: 'search.input.post',
         key: '<%= KEY %>',
         response,
       };

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -14,6 +14,7 @@ const appsToConvert = [
   {id: 82052, name: 'simple-oauth'},
   {id: 82250, name: 'search-oauth'},
   {id: 82251, name: 'basic-api-header'},
+  {id: 82460, name: 'custom-fields'},
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 


### PR DESCRIPTION
This PR adds [custom input field](https://zapier.github.io/zapier-platform-cli/#customdynamic-fields) support to `zapier convert`, specifically for searches and creates.