### PR TITLE
Log the user in if they try to push before they're logged in

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -5,7 +5,7 @@ const utils = require('../utils');
 
 const QUESTION_USERNAME = 'What is your Zapier login email address? (Ctrl-C to cancel)';
 const QUESTION_PASSWORD = 'What is your Zapier login password?';
-const login = (context) => {
+const login = (context, firstTime = true) => {
   const checks = [
     utils.readCredentials()
       .then(() => true)
@@ -42,7 +42,10 @@ const login = (context) => {
     })
     .then(utils.checkCredentials)
     .then(() => {
-      context.line(`Your deploy key has been saved to ${constants.AUTH_LOCATION}. Now try \`zapier init .\` to start a new local app.`);
+      context.line(`Your deploy key has been saved to ${constants.AUTH_LOCATION}. `);
+      if (firstTime) {
+        context.line('Now try `zapier init .` to start a new local app.\n');
+      }
     });
 };
 login.argsSpec = [];

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const utils = require('../utils');
 const constants = require('../constants');
 const register = require('./register');
+const login = require('./login');
 
 const build = require('./build');
 
@@ -18,7 +19,16 @@ const createIfNeeded = (context) => {
 const push = (context) => {
   context.line('Preparing to build and upload your app.\n');
 
-  return createIfNeeded(context)
+  return utils.readCredentials(null, false)
+    .then((creds) => {
+      if (_.isEmpty(creds)) {
+        context.line('Before you can push, you need to be logged in.\n');
+        return login(context, false);
+      } else {
+        return Promise.resolve();
+      }
+    })
+    .then(() => createIfNeeded(context))
     .then(() => utils.buildAndUploadDir())
     .then(() => {
       context.line(`\nBuild and upload complete! You should see it in your Zapier editor at ${constants.BASE_ENDPOINT}/app/editor now!`);


### PR DESCRIPTION
Fixes #119 

The only weird part is I tweaked `login` to take a default param, since the line about starting a new app with `zapier init .` doesn't always make sense. It's there by default, but we can log users in without it surfacing. 