### PR TITLE
zapier convert: Add support for basic auth mapping

### DIFF
--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -1,5 +1,6 @@
+<% if (customBasic) { %>
 const { replaceVars } = require('./utils');
-
+<% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <%
   Object.keys(mapping).forEach((mapperKey) => {

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -1,4 +1,6 @@
-<% if (before && !session && !oauth) { %>const maybeIncludeAuth = (request, z, bundle) => {
+const { replaceVars } = require('./utils');
+
+<% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <%
   Object.keys(mapping).forEach((mapperKey) => {
     fields.forEach((field) => {
@@ -12,6 +14,18 @@
     });
   });
 %>
+  return request;
+};
+<% } else if (customBasic) { %>
+const maybeIncludeAuth = (request, z, bundle) => {
+  const mapping = {
+    username: '<%= mapping.username %>',
+    password: '<%= mapping.password %>'
+  };
+  const username = replaceVars(mapping.username, bundle);
+  const password = replaceVars(mapping.password, bundle);
+  const encoded = `${username}:${password}`.toString('base64');
+  request.headers.Authorization = `Baisc ${encoded}`;
   return request;
 };
 <% }

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -25,7 +25,7 @@ const maybeIncludeAuth = (request, z, bundle) => {
   };
   const username = replaceVars(mapping.username, bundle);
   const password = replaceVars(mapping.password, bundle);
-  const encoded = `${username}:${password}`.toString('base64');
+  const encoded = new Buffer(`${username}:${password}`).toString('base64');
   request.headers.Authorization = `Baisc ${encoded}`;
   return request;
 };

--- a/scaffold/convert/index.template.js
+++ b/scaffold/convert/index.template.js
@@ -7,10 +7,8 @@
 const App = {
   version: require('./package.json').version,
   platformVersion: require('zapier-platform-core').version,
-<% if (hasAuth) { %>
+<% if (needsAuth) { %>
   authentication,
-<% } else { %>
-  authentication: {},
 <% } %>
   beforeRequest: [
     <%= BEFORE_REQUESTS %>

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -15,6 +15,7 @@ const appsToConvert = [
   {id: 82250, name: 'search-oauth'},
   {id: 82251, name: 'basic-api-header'},
   {id: 82460, name: 'custom-fields'},
+  {id: 80444, name: 'custom-baisc'},
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -120,7 +120,7 @@ describe('convert render functions', () => {
       const wbDef = definitions.noAuth;
       return convert.renderIndex(wbDef)
         .then(string => {
-          string.should.containEql('authentication: {}');
+          string.should.not.containEql('authentication:');
           convert.hasAuth(wbDef).should.be.false();
         });
     });

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -131,7 +131,7 @@ describe('convert render functions', () => {
       return convert.renderAuth(wbDef)
         .then(string => {
           const auth = loadAuthModuleFromString(string);
-          auth.type.should.eql('basic');
+          auth.type.should.eql('custom');
           auth.fields.should.eql([
             {
               key: 'username',
@@ -157,7 +157,7 @@ describe('convert render functions', () => {
       return convert.renderAuth(wbDef)
         .then(string => {
           const auth = loadAuthModuleFromString(string);
-          auth.type.should.eql('basic');
+          auth.type.should.eql('custom');
           auth.fields.should.eql([
             {
               key: 'username',
@@ -202,14 +202,12 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef)
         .then(string => {
-          string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+          string.trim().should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
 
   request.headers['Authorization'] = bundle.authData['api_key'];
 
   return request;
-};
-
-`);
+};`);
         });
     });
 
@@ -238,14 +236,12 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef)
         .then(string => {
-          string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+          string.trim().should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
 
   request.params['api_key'] = bundle.authData['api_key'];
 
   return request;
-};
-
-`);
+};`);
         });
     });
 
@@ -281,7 +277,7 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef)
         .then(string => {
-          string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+          string.trim().should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
 
   request.headers['X-Token'] = bundle.authData.sessionKey;
 
@@ -320,9 +316,7 @@ const getSessionKey = (z, bundle) => {
         sessionKey: firstKeyValue
       };
     });
-};
-
-`);
+};`);
         });
     });
 
@@ -371,14 +365,12 @@ const getSessionKey = (z, bundle) => {
 
       return convert.getHeader(wbDef)
         .then(string => {
-          string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+          string.trim().should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
 
   request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
 
   return request;
-};
-
-`);
+};`);
         });
     });
 
@@ -493,14 +485,12 @@ const getSessionKey = (z, bundle) => {
 
       return convert.getHeader(wbDef)
         .then(string => {
-          string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+          string.trim().should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
 
   request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
 
   return request;
-};
-
-`);
+};`);
         });
     });
 

--- a/src/tests/utils/definitions/basic-scripting.json
+++ b/src/tests/utils/definitions/basic-scripting.json
@@ -72,8 +72,8 @@
     "auth_data": {},
     "auth_label": "{{username}}",
     "auth_mapping": {
-      "Password": "{{password}}",
-      "Username": "{{username}}"
+      "password": "{{password}}",
+      "username": "{{username}}"
     },
     "auth_type": "Basic Auth",
     "auth_urls": {},

--- a/src/tests/utils/definitions/basic.json
+++ b/src/tests/utils/definitions/basic.json
@@ -72,8 +72,8 @@
     "auth_data": {},
     "auth_label": "{{username}}",
     "auth_mapping": {
-      "Password": "{{password}}",
-      "Username": "{{username}}"
+      "password": "{{password}}",
+      "username": "{{username}}"
     },
     "auth_type": "Basic Auth",
     "auth_urls": {},

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -598,15 +598,20 @@ const writeStep = (type, definition, key, legacyApp, newAppDir) => {
 };
 
 // render the authData used in the trigger/search/create test code
-const renderAuthData = (authType) => {
+const renderAuthData = (definition) => {
+  const authType = getAuthType(definition);
   let result;
   switch (authType) {
-  case 'basic':
+  case 'basic': {
+    let lines = _.map(definition.auth_fields, (field, key) => {
+      const upperKey = key.toUpperCase();
+      return `        ${key}: process.env.${upperKey}`;
+    });
     result = `{
-        username: process.env.USERNAME,
-        password: process.env.PASSWORD
+${lines.join(',\n')}
       }`;
     break;
+  }
   case 'oauth2':
     result = `{
         access_token: process.env.ACCESS_TOKEN
@@ -639,9 +644,8 @@ const renderAuthData = (authType) => {
 };
 
 const renderStepTest = (type, definition, key, legacyApp) => {
-  const authType = getAuthType(legacyApp);
   const label = definition.label || _.capitalize(key);
-  const authData = renderAuthData(authType);
+  const authData = renderAuthData(legacyApp);
   const templateContext = {
     KEY: key,
     LABEL: label,


### PR DESCRIPTION
This PR handles the case where a WB app with basic authentication has an [authentication mapping](https://zapier.com/developer/documentation/v2/authentication-mappings/). In CLI, we don't have authentication mappings. Instead, we just let users freely define their authentication in a function. So when converting a WB app like this, we need to use  `custom` auth type and mimic the mapping of the auth fields in the authentication function.

Example app to try out: [80444](https://zapier.com/developer/builder/app/80444/)