### PR TITLE
zapier convert: Use Prettier to format generated code

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "minimatch": "3.0.3",
     "node-fetch": "1.7.1",
     "normalize-path": "2.0.1",
+    "prettier": "1.9.1",
     "read": "1.0.7",
     "readable-stream": "2.2.2",
     "semver": "5.3.0",

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -203,12 +203,10 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef)
         .then(string => {
           string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-
   request.headers['Authorization'] = bundle.authData['api_key'];
 
   return request;
 };
-
 `);
         });
     });
@@ -239,12 +237,10 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef)
         .then(string => {
           string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-
   request.params['api_key'] = bundle.authData['api_key'];
 
   return request;
 };
-
 `);
         });
     });
@@ -282,7 +278,6 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef)
         .then(string => {
           string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-
   request.headers['X-Token'] = bundle.authData.sessionKey;
 
   return request;
@@ -304,24 +299,23 @@ const getSessionKey = (z, bundle) => {
   const getSessionEvent = {
     name: 'auth.session'
   };
-  return legacyScriptingRunner.runEvent(getSessionEvent, z, bundle)
-    .then((getSessionResult) => {
-      // IMPORTANT NOTE:
-      //   WB apps in scripting's get_session_info() allowed you to return any object and that would
-      //   be added to the authData, but CLI apps require you to specifically define those.
-      //   That means that if you return more than one key from your scripting's get_session_info(),
-      //   you might need to manually tweak this method to return that value at the end of this method,
-      //   and also add more fields to the authentication definition.
+  return legacyScriptingRunner.runEvent(getSessionEvent, z, bundle).then(getSessionResult => {
+    // IMPORTANT NOTE:
+    //   WB apps in scripting's get_session_info() allowed you to return any object and that would
+    //   be added to the authData, but CLI apps require you to specifically define those.
+    //   That means that if you return more than one key from your scripting's get_session_info(),
+    //   you might need to manually tweak this method to return that value at the end of this method,
+    //   and also add more fields to the authentication definition.
 
-      const resultKeys = Object.keys(getSessionResult);
-      const firstKeyValue = (getSessionResult && resultKeys.length > 0) ? getSessionResult[resultKeys[0]] : getSessionResult;
+    const resultKeys = Object.keys(getSessionResult);
+    const firstKeyValue =
+      getSessionResult && resultKeys.length > 0 ? getSessionResult[resultKeys[0]] : getSessionResult;
 
-      return {
-        sessionKey: firstKeyValue
-      };
-    });
+    return {
+      sessionKey: firstKeyValue
+    };
+  });
 };
-
 `);
         });
     });
@@ -372,12 +366,10 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef)
         .then(string => {
           string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-
   request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
 
   return request;
 };
-
 `);
         });
     });
@@ -494,12 +486,10 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef)
         .then(string => {
           string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-
   request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
 
   return request;
 };
-
 `);
         });
     });

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const path = require('path');
+const prettier = require('prettier');
 const stripComments = require('strip-comments');
 const {camelCase, snakeCase} = require('./misc');
 const {readFile, writeFile, ensureDir} = require('./files');
@@ -67,10 +68,26 @@ const stepDescriptionTemplateMap = {
   search: _.template('Finds a <%= lowerNoun %>.')
 };
 
-const renderTemplate = (templateFile, templateContext) => {
+const renderTemplate = (templateFile, templateContext, prettify = true) => {
   return readFile(templateFile)
     .then(templateBuf => templateBuf.toString())
-    .then(template => _.template(template, {interpolate: /<%=([\s\S]+?)%>/g})(templateContext));
+    .then(template => _.template(template, {interpolate: /<%=([\s\S]+?)%>/g})(templateContext))
+    .then(content => {
+      if (prettify) {
+        const ext = path.extname(templateFile).toLowerCase();
+        const prettifier = {
+          '.json': origString => JSON.stringify(JSON.parse(origString), null, 2),
+          '.js': origString => prettier.format(origString, {
+            singleQuote: true,
+            printWidth: 120
+          })
+        }[ext];
+        if (prettifier) {
+          return prettifier(content);
+        }
+      }
+      return content;
+    });
 };
 
 const createFile = (content, fileName, dir) => {
@@ -765,7 +782,7 @@ const renderScripting = (legacyApp) => {
   templateContext.CODE = templateContext.CODE.replace("'use strict';\n", '').replace('"use strict";\n', '');
 
   const templateFile = path.join(TEMPLATE_DIR, '/scripting.template.js');
-  return renderTemplate(templateFile, templateContext);
+  return renderTemplate(templateFile, templateContext, false);
 };
 
 const writeScripting = (legacyApp, newAppDir) => {


### PR DESCRIPTION
We use [these templates](https://github.com/zapier/zapier-platform-cli/tree/7a5d22f41609aa839f6e975d95620f04c84ad588/scaffold/convert) to generate code for converted apps. The generated code is not pretty and it's not easy to manually format code in the templates. This PR adds [Prettier](https://prettier.io) into the conversion process so all the rendered `.json` and `.js` files are prettified with `JSON.stringify` and Prettier respectively before they get written to the filesystem.