### PR TITLE
zapier convert: Add support for search-or-creates

### DIFF
--- a/scaffold/convert/index.template.js
+++ b/scaffold/convert/index.template.js
@@ -33,8 +33,10 @@ const App = {
 
   creates: {
     <%= CREATES %>
-  }
-
+  },
+<% if (SEARCH_OR_CREATES) { %>
+  searchOrCreates: <%= SEARCH_OR_CREATES %>
+<% } %>
 };
 
 module.exports = App;

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -15,6 +15,7 @@ const appsToConvert = [
   {id: 82250, name: 'search-oauth'},
   {id: 82251, name: 'basic-api-header'},
   {id: 82460, name: 'custom-fields'},
+  {id: 83195, name: 'search-or-create'},
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -16,7 +16,7 @@ const appsToConvert = [
   { id: 82251, name: 'basic-api-header' },
   { id: 82460, name: 'custom-fields' },
   { id: 83195, name: 'search-or-create' },
-  { id: 80444, name: 'custom-baisc' },
+  { id: 80444, name: 'custom-basic' },
   { id: 83073, name: 'send-in-json' },
   { id: 83342, name: 'replace-vars' }
   // TODO: Add more apps that use different scripting methods, as we start to support them

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -677,6 +677,25 @@ const writeUtils = (newAppDir) => {
     .then(content => createFile(content, fileName, newAppDir));
 };
 
+const findSearchOrCreates = (legacyApp) => {
+  let searchOrCreates = {};
+  _.each(legacyApp.searches, (searchDef, searchKey) => {
+    if (searchDef.action_pair_key) {
+      const comboKey = `${searchKey}_${searchDef.action_pair_key}`;
+      searchOrCreates[comboKey] = {
+        key: comboKey,
+        display: {
+          label: searchDef.action_pair_label || '',
+          description: searchDef.action_pair_label || ''
+        },
+        search: searchKey,
+        create: searchDef.action_pair_key
+      };
+    }
+  });
+  return searchOrCreates;
+};
+
 const renderIndex = (legacyApp) => {
   const _hasAuth = hasAuth(legacyApp);
   const templateContext = {
@@ -720,6 +739,13 @@ const renderIndex = (legacyApp) => {
       });
 
       templateContext.REQUIRES = importLines.join('\n');
+
+      const searchOrCreates = findSearchOrCreates(legacyApp);
+      if (_.isEmpty(searchOrCreates)) {
+        templateContext.SEARCH_OR_CREATES = null;
+      } else {
+        templateContext.SEARCH_OR_CREATES = JSON.stringify(searchOrCreates, null, 2);
+      }
 
       const templateFile = path.join(TEMPLATE_DIR, '/index.template.js');
       return renderTemplate(templateFile, templateContext);

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -681,7 +681,11 @@ const findSearchOrCreates = (legacyApp) => {
   let searchOrCreates = {};
   _.each(legacyApp.searches, (searchDef, searchKey) => {
     if (searchDef.action_pair_key) {
-      const comboKey = `${searchKey}_${searchDef.action_pair_key}`;
+      // The key for a searchOrCreate (comboKey) has to match the key of a
+      // search due to frontend constraints. From Platform's perspective
+      // though, a searchOrCreate just needs a unique key that could be
+      // anything.
+      const comboKey = searchKey;
       searchOrCreates[comboKey] = {
         key: comboKey,
         display: {


### PR DESCRIPTION
This PR adds an entry to `App.searchOrCreates` whenever it finds a search paired with a create.

Example app to try out: [83195](https://zapier.com/developer/builder/app/83195/development)