### PR TITLE
zapier convert: Replace variables in URLs (PDE-10)

### DIFF
--- a/scaffold/convert/create-test.template.js
+++ b/scaffold/convert/create-test.template.js
@@ -11,9 +11,9 @@ describe('Creates - <%= LABEL %>', () => {
   it('should create an object', (done) => {
     const bundle = {
       authData: <%= AUTH_DATA %>,
-      inputData: {
-        name: 'Testing',
-      },
+<% if (INPUT_DATA) { %>
+      inputData: <%= INPUT_DATA %>
+<% } %>
     };
 
     appTester(App.creates['<%= KEY %>'].operation.perform, bundle)

--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -8,6 +8,7 @@ const makeRequest = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_write() from scripting.
   const preWriteEvent = {
@@ -28,6 +29,7 @@ const makeRequest = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_write() from scripting.
   const preWriteEvent = {
@@ -56,6 +58,7 @@ const makeRequest = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -81,6 +84,7 @@ const makeRequest = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _write() from scripting.
   const fullWriteEvent = {
@@ -95,8 +99,11 @@ const makeRequest = (z, bundle) => {
 // If there's no scripting, it's even sweeter and simpler!
 if (!preScripting && !postScripting && !fullScripting) { %>
 const makeRequest = (z, bundle) => {
+  let url = '<%= URL %>';
+  url = replaceVars(url, bundle);
+
   const responsePromise = z.request({
-    url: '<%= URL %>',
+    url: url,
     method: 'POST',
     body: bundle.inputData
   });
@@ -111,7 +118,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _custom_action_fields() from scripting.
   const fullFieldsEvent = {
@@ -126,7 +133,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_action_fields() from scripting.
   const preFieldsEvent = {
@@ -143,7 +150,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_action_fields() from scripting.
   const preFieldsEvent = {
@@ -168,7 +175,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -187,7 +194,7 @@ const getInputFields = (z, bundle) => {
 <% } else if (hasCustomInputFields) { %>
 const getInputFields = (z, bundle) => {
   let url = '<%= CUSTOM_FIELDS_URL %>';
-  url = replaceVars(url, bundle, {});
+  url = replaceVars(url, bundle);
 
   const responsePromise = z.request({
     url: url
@@ -203,7 +210,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _custom_action_result_fields() from scripting.
   const fullResultFieldsEvent = {
@@ -218,7 +225,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -235,7 +242,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -260,7 +267,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -279,7 +286,7 @@ const getOutputFields = (z, bundle) => {
 <% } else if (hasCustomOutputFields) { %>
 const getOutputFields = (z, bundle) => {
   let url = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  url = replaceVars(url, bundle, {});
+  url = replaceVars(url, bundle);
 
   const responsePromise = z.request({
     url: url

--- a/scaffold/convert/oauth2.template.js
+++ b/scaffold/convert/oauth2.template.js
@@ -1,3 +1,4 @@
+const { replaceVars } = require('./utils');
 const testTrigger = require('<%= TEST_TRIGGER_MODULE %>');
 <% if (hasPreOAuthTokenScripting && hasPostOAuthTokenScripting) { %>
 const getAccessToken = (z, bundle) => {
@@ -5,6 +6,7 @@ const getAccessToken = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= ACCESS_TOKEN_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a pre_oauthv2_token() from scripting.
   const preOAuth2TokenEvent = {
@@ -31,6 +33,7 @@ const getAccessToken = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= ACCESS_TOKEN_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a pre_oauthv2_token() from scripting.
   const preOAuth2TokenEvent = {
@@ -51,6 +54,7 @@ const getAccessToken = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= ACCESS_TOKEN_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     method: 'POST',
@@ -82,6 +86,7 @@ const refreshAccessToken = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= REFRESH_TOKEN_URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a pre_oauthv2_refresh() from scripting.
   const preOAuth2RefreshEvent = {

--- a/scaffold/convert/search-test.template.js
+++ b/scaffold/convert/search-test.template.js
@@ -10,7 +10,10 @@ describe('Searches - <%= LABEL %>', () => {
 
   it('should get an object', (done) => {
     const bundle = {
-      authData: <%= AUTH_DATA %>
+      authData: <%= AUTH_DATA %>,
+<% if (INPUT_DATA) { %>
+      inputData: <%= INPUT_DATA %>
+<% } %>
     };
 
     appTester(App.searches['<%= KEY %>'].operation.perform, bundle)

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -12,6 +12,8 @@ const getList = (z, bundle) => {
   const resourceBundle = _.cloneDeep(bundle);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
   // Do a _pre_search() from scripting.
@@ -52,7 +54,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -85,7 +87,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -168,6 +170,8 @@ const getList = (z, bundle) => {
   const resourceBundle = _.cloneDeep(bundle);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
   // Do a _pre_search() from scripting.
@@ -196,6 +200,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
     .then((results) => {
@@ -217,7 +222,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -250,7 +255,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -271,7 +276,7 @@ const getList = (z, bundle) => {
 
       resourceBundle.results = results;
 
-      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return z.request({ url: finalUrl });
     })
     .then((response) => {
@@ -329,6 +334,8 @@ const getList = (z, bundle) => {
   const resourceBundle = _.cloneDeep(bundle);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
   const responsePromise = z.request({
@@ -354,6 +361,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
     .then((results) => {
@@ -375,7 +383,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -408,7 +416,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -429,7 +437,7 @@ const getList = (z, bundle) => {
 
       resourceBundle.results = results;
 
-      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0, ));
       return z.request({ url: finalUrl });
     })
     .then((response) => {
@@ -487,6 +495,8 @@ const getList = (z, bundle) => {
   const resourceBundle = _.cloneDeep(bundle);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
   // Do a _search() from scripting.
@@ -505,6 +515,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
     .then((results) => {
@@ -526,7 +537,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -559,7 +570,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -580,7 +591,7 @@ const getList = (z, bundle) => {
 
       resourceBundle.results = results;
 
-      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return z.request({ url: finalUrl });
     })
     .then((response) => {
@@ -639,6 +650,8 @@ const getList = (z, bundle) => {
   const resourceBundle = _.cloneDeep(bundle);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
   const responsePromise = z.request({
@@ -655,6 +668,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
+      resourceBundle._legacyUrl = replaceVars(bundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
     .then((results) => {
@@ -676,7 +690,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -709,7 +723,7 @@ const getList = (z, bundle) => {
         key: '<%= KEY %>',
         results,
       };
-      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, '[0]', {}));
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
     .then((preResourceResult) => z.request(preResourceResult))
@@ -787,7 +801,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _custom_search_fields() from scripting.
   const fullFieldsEvent = {
@@ -802,7 +816,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
@@ -819,7 +833,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
@@ -844,7 +858,7 @@ const getInputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -863,11 +877,9 @@ const getInputFields = (z, bundle) => {
 <% } else if (hasCustomInputFields) { %>
 const getInputFields = (z, bundle) => {
   let url = '<%= CUSTOM_FIELDS_URL %>';
-  url = replaceVars(url, bundle, {});
+  url = replaceVars(url, bundle);
 
-  const responsePromise = z.request({
-    url: url
-  });
+  const responsePromise = z.request({ url });
   return responsePromise
     .then((response) => z.JSON.parse(response.content));
 };
@@ -879,7 +891,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _custom_search_result_fields() from scripting.
   const fullResultFieldsEvent = {
@@ -894,7 +906,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -911,7 +923,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -936,7 +948,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -955,11 +967,9 @@ const getOutputFields = (z, bundle) => {
 <% } else if (hasCustomOutputFields) { %>
 const getOutputFields = (z, bundle) => {
   let url = '<%= CUSTOM_FIELDS_RESULT_URL %>';
-  url = replaceVars(url, bundle, {});
+  url = replaceVars(url, bundle);
 
-  const responsePromise = z.request({
-    url: url
-  });
+  const responsePromise = z.request({ url });
   return responsePromise
     .then((response) => z.JSON.parse(response.content));
 };

--- a/scaffold/convert/trigger-test.template.js
+++ b/scaffold/convert/trigger-test.template.js
@@ -10,7 +10,10 @@ describe('Triggers - <%= LABEL %>', () => {
 
   it('should get an array', (done) => {
     const bundle = {
-      authData: <%= AUTH_DATA %>
+      authData: <%= AUTH_DATA %>,
+<% if (INPUT_DATA) { %>
+      inputData: <%= INPUT_DATA %>
+<% } %>
     };
 
     appTester(App.triggers['<%= KEY %>'].operation.perform, bundle)

--- a/scaffold/convert/trigger.template.js
+++ b/scaffold/convert/trigger.template.js
@@ -8,6 +8,7 @@ const getList = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_poll() from scripting.
   const prePollEvent = {
@@ -28,6 +29,7 @@ const getList = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_poll() from scripting.
   const prePollEvent = {
@@ -56,6 +58,7 @@ const getList = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -81,6 +84,7 @@ const getList = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= URL %>';
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _poll() from scripting.
   const fullPollEvent = {
@@ -95,9 +99,10 @@ const getList = (z, bundle) => {
 // If there's no scripting, it's even sweeter and simpler!
 if (!preScripting && !postScripting && !fullScripting) { %>
 const getList = (z, bundle) => {
-  const responsePromise = z.request({
-    url: '<%= URL %>'
-  });
+  let url = '<%= URL %>';
+  url = replaceVars(url, bundle);
+
+  const responsePromise = z.request({ url });
   return responsePromise
     .then(response => z.JSON.parse(response.content));
 };
@@ -109,7 +114,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
@@ -126,7 +131,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
@@ -151,7 +156,7 @@ const getOutputFields = (z, bundle) => {
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
-  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle, {});
+  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
   const responsePromise = z.request({
     url: bundle._legacyUrl

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -15,7 +15,8 @@ const appsToConvert = [
   { id: 82250, name: 'search-oauth' },
   { id: 82251, name: 'basic-api-header' },
   { id: 82460, name: 'custom-fields' },
-  { id: 80444, name: 'custom-baisc' }
+  { id: 80444, name: 'custom-baisc' },
+  { id: 83342, name: 'replace-vars' }
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -144,6 +144,10 @@ const renderField = (definition, key, indent = 0) => {
     props.push(renderProp('search', quote(definition.searchfill)));
   }
 
+  if (definition.default) {
+    props.push(renderProp('default', quote(escapeSpecialChars(definition.default))));
+  }
+
   props = props.map(s => ' '.repeat(indent + 2) + s);
   const padding = ' '.repeat(indent);
 
@@ -642,14 +646,27 @@ const renderAuthData = (authType) => {
   return result;
 };
 
+const renderDefaultInputData = (definition) => {
+  const lines = [];
+  _.each(definition.fields, (field, key) => {
+    if (field.default) {
+      const defaultValue = escapeSpecialChars(field.default);
+      lines.push(`'${key}': '${defaultValue}'`);
+    }
+  });
+  return '{' + lines.join(',\n') + '}';
+};
+
 const renderStepTest = (type, definition, key, legacyApp) => {
   const authType = getAuthType(legacyApp);
   const label = definition.label || _.capitalize(key);
   const authData = renderAuthData(authType);
+  const inputData = renderDefaultInputData(definition);
   const templateContext = {
     KEY: key,
     LABEL: label,
-    AUTH_DATA: authData
+    AUTH_DATA: authData,
+    INPUT_DATA: inputData
   };
   const templateFile = path.join(TEMPLATE_DIR, `/${type}-test.template.js`);
   return renderTemplate(templateFile, templateContext);


### PR DESCRIPTION
Developers can put variables from in a URL, such as `https://{{account}}.example.com/{{resource_name}}`. This PR makes sure we replace those variables in URLs before we send requests.

Example app to try out: [83342](https://zapier.com/developer/builder/app/83342/development):
```
zapier convert 83342 replace-vars
cd replace-vars
npm install
zapier test
```

Expect `zapier test` to fail on a TypeError for test case `Full Search` and `Full Trigger` due to a bug in core, which was addressed in zapier/zapier-platform-core#59.