### PR TITLE
use default update interval (daily)

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -27,10 +27,7 @@ module.exports = argv => {
     process.exit(1);
   }
 
-  const notifier = updateNotifier({
-    pkg: require('../package.json'),
-    updateCheckInterval: 0
-  });
+  const notifier = updateNotifier({ pkg: require('../package.json') });
 
   if (notifier.update) {
     notifier.notify({


### PR DESCRIPTION
See [this comment](https://github.com/zapier/zapier-platform-cli/pull/188#issuecomment-352499434). We don't want to bug users every single time they run a CLI command. 