### PR TITLE
zapier convert: Use Buffer.from() instead of Buffer constructor

### DIFF
--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -25,7 +25,7 @@ const maybeIncludeAuth = (request, z, bundle) => {
   };
   const username = replaceVars(mapping.username, bundle);
   const password = replaceVars(mapping.password, bundle);
-  const encoded = new Buffer(`${username}:${password}`).toString('base64');
+  const encoded = Buffer.from(`${username}:${password}`).toString('base64');
   request.headers.Authorization = `Basic ${encoded}`;
   return request;
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -249,7 +249,7 @@ const upload = (zipPath, appDir) => {
       const definition = JSON.parse(definitionJson);
 
       const binaryZip = fs.readFileSync(fullZipPath);
-      const buffer = new Buffer(binaryZip).toString('base64');
+      const buffer = Buffer.from(binaryZip).toString('base64');
 
       printStarting(`Uploading version ${definition.version}`);
       return callAPI(`/apps/${app.id}/versions/${definition.version}`, {


### PR DESCRIPTION
See https://eslint.org/docs/rules/no-buffer-constructor