### PR TITLE
Increase test time limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint-snippets":
       "node_modules/.bin/eslint snippets --rule 'no-unused-vars: 0'",
     "test":
-      "npm run build && node_modules/mocha/bin/mocha -t 15000 --recursive lib/tests && npm run lint && npm run lint-snippets",
+      "npm run build && node_modules/mocha/bin/mocha -t 30000 --recursive lib/tests && npm run lint && npm run lint-snippets",
     "zapier": "zapier.js",
     "validate-templates": "./scripts/validate-app-templates.js",
     "set-template-versions": "./scripts/set-app-template-versions.js",


### PR DESCRIPTION
Attempts to fix the following error on Travis:

```
1) build should list only required files:

  Error: Timeout of 15000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```