### PR TITLE
use actual json endpoint for scaffold triggers

### DIFF
--- a/scaffold/create.template.js
+++ b/scaffold/create.template.js
@@ -2,7 +2,7 @@
 const create<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
     method: 'POST',
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     body: JSON.stringify({
       name: bundle.inputData.name
     })

--- a/scaffold/resource.template.js
+++ b/scaffold/resource.template.js
@@ -1,7 +1,7 @@
 // get a single <%= LOWER_NOUN %>
 const get<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
-    url: `http://example.com/api/<%= KEY %>s/${bundle.inputData.id}.json`,
+    url: `https://jsonplaceholder.typicode.com/posts/${bundle.inputData.id}`,
   });
   return responsePromise
     .then(response => JSON.parse(response.content));
@@ -10,7 +10,7 @@ const get<%= CAMEL %> = (z, bundle) => {
 // get a list of <%= LOWER_NOUN %>s
 const list<%= CAMEL %>s = (z) => {
   const responsePromise = z.request({
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       order_by: 'id desc'
     }
@@ -22,7 +22,7 @@ const list<%= CAMEL %>s = (z) => {
 // find a particular <%= LOWER_NOUN %> by name
 const search<%= CAMEL %>s = (z, bundle) => {
   const responsePromise = z.request({
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       query: `name:${bundle.inputData.name}`
     }
@@ -35,7 +35,7 @@ const search<%= CAMEL %>s = (z, bundle) => {
 const create<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
     method: 'POST',
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     body: {
       name: bundle.inputData.name // json by default
     }

--- a/scaffold/search.template.js
+++ b/scaffold/search.template.js
@@ -1,7 +1,7 @@
 // find a particular <%= LOWER_NOUN %> by name
 const search<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       name: bundle.inputData.name
     }

--- a/scaffold/trigger.template.js
+++ b/scaffold/trigger.template.js
@@ -1,7 +1,7 @@
 // triggers on <%= LOWER_NOUN %> with a certain tag
 const trigger<%= CAMEL %> = (z, bundle) => {
   const responsePromise = z.request({
-    url: 'http://example.com/api/<%= KEY %>s.json',
+    url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       tag: bundle.inputData.tagName
     }


### PR DESCRIPTION
Before this PR, the scaffolded steps all used `http://example.com/<key>.json` which looks nice, but returns busted html whenever it's called. Instead, I switched the scaffolded steps to use https://jsonplaceholder.typicode.com, which is a test utility that supports all manner of endpoints and verbs. I'm using the default public stuff right now, but it's open source and we could customize it and host it ourselves if we want. The biggest advantage to self-hosting would be we could create wildcard endpoints to match the scaffold name (`/whatever` would work), but this seems straightforward enough as not to confuse devs. 

Now, the scaffolded tests actually run!

Before: 
<img width="497" alt="screen shot 2017-12-21 at 12 57 57 am" src="https://user-images.githubusercontent.com/1231935/34244259-11955144-e5ea-11e7-9bb7-ba09e1999f35.png">

After:
<img width="290" alt="screen shot 2017-12-21 at 12 58 16 am" src="https://user-images.githubusercontent.com/1231935/34244260-11a48ad8-e5ea-11e7-8d75-7d890a93460b.png">

