### PR TITLE
Escape line breaks when generating package.json

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -922,7 +922,7 @@ const renderPackageJson = legacyApp => {
 
   const templateContext = {
     NAME: _.kebabCase(legacyApp.general.title),
-    DESCRIPTION: escapeSpecialChars(legacyApp.general.description);
+    DESCRIPTION: escapeSpecialChars(legacyApp.general.description)
   };
 
   const zapierCoreVersion = require('../../package.json').version;

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -922,7 +922,7 @@ const renderPackageJson = legacyApp => {
 
   const templateContext = {
     NAME: _.kebabCase(legacyApp.general.title),
-    DESCRIPTION: legacyApp.general.description
+    DESCRIPTION: escapeSpecialChars(legacyApp.general.description);
   };
 
   const zapierCoreVersion = require('../../package.json').version;


### PR DESCRIPTION
Running `zapier convert` for an existing Zapier app with a multiline description generated an invalid JSON in package.json which then causes the whole process to fail with something similar to 

```
Error! Unexpected token
 in JSON at position 149
```