### PR TITLE
Allow never versions of Node.js

### DIFF
--- a/src/version-store.js
+++ b/src/version-store.js
@@ -5,5 +5,5 @@ module.exports = [
   { nodeVersion: '4.3.2', npmVersion: '>=2.14.12' }, // 1.x
   { nodeVersion: '6.10.2', npmVersion: '>=3.10.10' }, // 2.x
   { nodeVersion: '6.10.2', npmVersion: '>=3.10.10' }, // 3.x
-  { nodeVersion: '6.10.2', npmVersion: '>=3.10.10' } // 4.x
+  { nodeVersion: '>=6.10.2', npmVersion: '>=3.10.10' } // 4.x
 ];


### PR DESCRIPTION
Allow never versions of Node.js instead of requiring the exact version 6.10.2. Making this change will make it possible to use Yarn to install packages.

Reproducing the error in Yarn:
```shell
# create a directory with the minimum required files:
zapier init example-app
# move into the new directory:
cd example-app
# Install packages using Yarn instead of npm:
yarn install
> error zapier-platform-example-app-minimal@1.0.0: The engine "node" is incompatible with this module. Expected version "6.10.2".
```

Changing `"node": "6.10.2",` to `"node": ">=6.10.2",` in `package.json` fixes this issue.

I must admit that I have not double checked that this code change does indeed add `>=` in front of the node version number in `package.json` when running `zapier init example-app`.