### PR TITLE
doc cleaning and examples

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -1209,13 +1209,14 @@ See [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/Example-Apps) 
 
 ## FAQs
 
-*Q: Why doesn't Zapier support newer versions of Node.js?*
+### Why doesn't Zapier support newer versions of Node.js?
 
-A: We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) of Node (the latest of which is `LAMBDA_VERSION`. As that updates, so too will we.
+We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) of Node (the latest of which is `LAMBDA_VERSION`. As that updates, so too will we.
 
-*Q: Does Zapier support XML (SOAP) APIs?*
 
-A: Not natively, but it can! Users have reported that the following `npm` modules are compatible with the CLI Platform:
+### Does Zapier support XML (SOAP) APIs?
+
+Not natively, but it can! Users have reported that the following `npm` modules are compatible with the CLI Platform:
 
 * [pixl-xml](https://github.com/jhuckaby/pixl-xml)
 * [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js)
@@ -1225,9 +1226,9 @@ A: Not natively, but it can! Users have reported that the following `npm` module
 [insert-file:./snippets/xml.js]
 ```
 
-*Q: Is it possible to iterate over pages in a polling trigger?*
+### Is it possible to iterate over pages in a polling trigger?
 
-A: Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).
+Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).
 
 ```javascript
 [insert-file:./snippets/paging-poll.js]
@@ -1239,11 +1240,11 @@ If you need to do more requests conditionally based on the results of an HTTP ca
 [insert-file:./snippets/async-polling.js]
 ```
 
-*Q: How do I manually set the Node.js version to run my app with?*
+### How do I manually set the Node.js version to run my app with?
 
-A: Update your `zapier-platform-core` dependency in `package.json`.  Each major version ties to a specific version of Node.js. You can find the mapping [here](https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js). We only support the version(s) supported by [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).
+Update your `zapier-platform-core` dependency in `package.json`.  Each major version ties to a specific version of Node.js. You can find the mapping [here](https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js). We only support the version(s) supported by [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).
 
-*Q: How do search-powered fields relate to dynamic dropdowns and why are they both required together?*
+### How do search-powered fields relate to dynamic dropdowns and why are they both required together?
 
 To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.
 
@@ -1267,10 +1268,9 @@ If the connection between steps 3 and 4 is a common one, you can indicate that i
 This is paired most often with "update" actions, where a required parameter will be a resource id.
 
 <a id="paging"></a>
+### What's the deal with pagination? When is it used and how does it work?
 
-*Q: What's the deal with pagination? When is it used and how does it work?*
-
-A: Paging is **only used when a trigger is part of a dynamic dropdown**. Depending on how many items exist and how many are returned in the first poll, it's possible that the resource the user is looking for isn't in the initial poll. If they hit the "see more" button, we'll increment the value of `bundle.meta.page` and poll again.
+Paging is **only used when a trigger is part of a dynamic dropdown**. Depending on how many items exist and how many are returned in the first poll, it's possible that the resource the user is looking for isn't in the initial poll. If they hit the "see more" button, we'll increment the value of `bundle.meta.page` and poll again.
 
 Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a `start` parameter:
 
@@ -1290,18 +1290,17 @@ const getList = (z, bundle) => {
 Lastly, you need to set `canPaginate` to `true` in your polling definition (per the [schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema)).
 
 <a id="dedup"></a>
+### How does deduplication work?
 
-*Q: How does deduplication work?*
-
-A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
+Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
 
 For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
 
 There's a more in-depth explanation [here](https://zapier.com/developer/documentation/v2/deduplication/).
 
-*Q: Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!*
+### Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!
 
-A: For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:
+For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:
 
 ```js
 // ...

--- a/README-source.md
+++ b/README-source.md
@@ -600,7 +600,7 @@ This object holds the user's auth details and the data for the API requests.
 
 | key | default | description |
 | --- | --- | --- |
-| frontend | `false` | if true, this run was initiated manually via the zap editor |
+| frontend | `false` | if true, this run was initiated manually via the Zap editor |
 | prefill | `false` | if true, this poll is being used to populate a dynamic dropdown |
 | hydrate | `true`  | if true, the results of this run will be hydrated (false if we're in the middle of hydrating already) |
 | test_poll | `false` | if true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) on the auth |
@@ -1068,7 +1068,18 @@ zapier test
 
 ### Testing & Environment Variables
 
-These work much like normal environment variables - for example:
+The best way to store sensitive values (like API keys, OAuth secrets, or passwords) is in an `.environment` file ([learn more](https://github.com/motdotla/dotenv#faq)). Then, you can include the following before your tests run:
+
+```js
+const zapier = require('zapier-platform-core');
+zapier.tools.env.inject(); // inject() can take a filename; defaults to ".environment"
+
+// now process.env has all the values in your .environment file
+```
+
+> Remember: don't add your secrets file to version control!
+
+Additionally, you can provide them dynamically at runtime:
 
 ```bash
 CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -1236,11 +1247,11 @@ A: Update your `zapier-platform-core` dependency in `package.json`.  Each major 
 
 To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.
 
-When users are selecting specific resources (for instance, a Google Sheet), it's important they're able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via `id` instead. Rather than directing the user copy and paste and id for every item they might encounter, there is the notion of a **dynamic dropdown**. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item's name:
+When users are selecting specific resources (for instance, a Google Sheet), it's important they're able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via `id` instead. Rather than directing the user copy and paste an id for every item they might encounter, there is the notion of a **dynamic dropdown**. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item's name:
 
 ![](https://cdn.zapier.com/storage/photos/fb56bdc2aab91504be0e51800bec4d64.png)
 
-The field's value reaches your app as an id. You define this connection with the `dynamic` property, which is a string: `trigger_key.id_key.label_key`. This approach works great if the user setting up the zap always wants the zap to use the same spreadsheet. They specify the id during setup and the zap runs happily.
+The field's value reaches your app as an id. You define this connection with the `dynamic` property, which is a string: `trigger_key.id_key.label_key`. This approach works great if the user setting up the Zap always wants the Zap to use the same spreadsheet. They specify the id during setup and the Zap runs happily.
 
 **Search fields** take this connection a step further. Rather than set the spreadsheet id at setup, the user could precede the action with a search field to make the id dynamic. For instance, let's say you have a different spreadsheet for every day of the week. You could build the following zap:
 
@@ -1249,7 +1260,7 @@ The field's value reaches your app as an id. You define this connection with the
 3. Find the spreadsheet that matches the day from Step 2
 4. Update the spreadsheet (with the id from step 3) with some data
 
-If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying `search` as a `search_key.id_key`. When paired **with a dynamic dropdown**, this will add a button to the editor that will add the search step to the user's zap and map the id field correctly.
+If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying `search` as a `search_key.id_key`. When paired **with a dynamic dropdown**, this will add a button to the editor that will add the search step to the user's Zap and map the id field correctly.
 
 ![](https://cdn.zapier.com/storage/photos/d263fd3a56cf8108cb89195163e7c9aa.png)
 
@@ -1282,7 +1293,7 @@ Lastly, you need to set `canPaginate` to `true` in your polling definition (per 
 
 *Q: How does deduplication work?*
 
-A: Each time a polling zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
+A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
 
 For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
 

--- a/README.md
+++ b/README.md
@@ -602,11 +602,11 @@ Zapier's OAuth2 implementation is based on the `authorization_code` flow, simila
 
 It looks like this:
 
- 1. Zapier sends the user to the authorization URL defined by your App
- 1. Once authorized, your website sends the user to the `redirect_uri` Zapier provided (`zapier describe` to find out what it is)
- 1. Zapier makes a call on the backend to your API to exchange the `code` for an `access_token`
- 1. Zapier remembers the `access_token` and makes calls on behalf of the user
- 1. (Optionally) Zapier can refresh the token if it expires
+  1. Zapier sends the user to the authorization URL defined by your App
+  2. Once authorized, your website sends the user to the `redirect_uri` Zapier provided (`zapier describe` to find out what it is)
+  3. Zapier makes a call on the backend to your API to exchange the `code` for an `access_token`
+  4. Zapier remembers the `access_token` and makes calls on behalf of the user
+  5. (Optionally) Zapier can refresh the token if it expires
 
 You are required to define the authorization URL and the API call to fetch the access token. You'll also likely want to set your `CLIENT_ID` and `CLIENT_SECRET` as environment variables:
 
@@ -1147,8 +1147,8 @@ This object holds the user's auth details and the data for the API requests.
 
 ```javascript
 {
-  createdBy: 'Bobby Flay'
-  style: 'mediterranean'
+  createdBy: 'his name is Bobby Flay'
+  style: 'he cooks mediterranean'
 }
 ```
 
@@ -1158,42 +1158,27 @@ This object holds the user's auth details and the data for the API requests.
 
 ```javascript
 {
-  createdBy: '{{chef_name}}'
-  style: '{{style}}'
+  createdBy: 'his name is {{123__chef_name}}'
+  style: 'he cooks {{456__style}}'
 }
 ```
+
+> "curlies" are data mapped in from previous steps. They take the form `{{NODE_ID__key_name}}`. You'll usually want to use `bundle.inputData` instead.
 
 ### `bundle.meta`
 
-`bundle.meta` is extra information useful for doing advanced behaviors depending on what the user is doing. It looks something like this:
+`bundle.meta` is extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:
 
-```javascript
-{
-  frontend: false,
-  prefill: false,
-  hydrate: true,
-  test_poll: false,
-  standard_poll: true,
-  first_poll: false,
-  limit: -1,
-  page: 0,
-}
-```
-
-For example - if you want to do pagination - you could do:
-
-```javascript
-const getList = (z, bundle) => {
-  const promise = z.request({
-    url: 'http://example.com/api/list.json',
-    params: {
-      limit: 100,
-      offset: 100 * bundle.meta.page
-    }
-  });
-  return promise.then((response) => response.json);
-};
-```
+| key | default | description |
+| --- | --- | --- |
+| frontend | `false` | if true, this run was initiated manually via the Zap editor |
+| prefill | `false` | if true, this poll is being used to populate a dynamic dropdown |
+| hydrate | `true`  | if true, the results of this run will be hydrated (false if we're in the middle of hydrating already) |
+| test_poll | `false` | if true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) on the auth |
+| standard_poll| `true`  | the opposite of `test_poll` |
+| first_poll | `false` | if true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. See: [deduplication](#dedup) |
+| limit | `-1` | the number of items to fetch. `-1` indicates there's no limit (which will almost always be the case) |
+| page | `0` | used in [paging](#paging) to uniquely identify which page of results should be returned |
 
 **`bundle.meta.zap.id` is only available in the `performSubscribe` and `performUnsubscribe` methods**
 
@@ -1322,13 +1307,13 @@ const App = {
 There are two primary ways to make HTTP requests in the Zapier platform:
 
 1. **Shorthand HTTP Requests** - these are simple object literals that make it easy to define simple requests.
-1. **Manual HTTP Requests** - this is much less "magic", you use `z.request([url], options)` to make the requests and control the response.
+2. **Manual HTTP Requests** - you use `z.request([url], options)` to make the requests and control the response. Use this when you need to change options for certain requests (for all requests, use middleware).
 
 There are also a few helper constructs you can use to reduce boilerplate:
 
 1. `requestTemplate` which is an shorthand HTTP request that will be merged with every request.
 2. `beforeRequest` middleware which is an array of functions to mutate a request before it is sent.
-2. `afterResponse` middleware which is an array of functions to mutate a response before it is completed.
+3. `afterResponse` middleware which is an array of functions to mutate a response before it is completed.
 
 > Note: you can install any HTTP client you like - but this is greatly discouraged as you lose [automatic HTTP logging](#http-logging) and middleware.
 
@@ -1464,19 +1449,19 @@ If you need to process all HTTP requests in a certain way, you may be able to us
 Try putting them in your app definition:
 
 ```javascript
-const addHeader = (request /*, z*/) => {
+const addHeader = (request, z, bundle) => {
   request.headers['my-header'] = 'from zapier';
   return request;
 };
 
-const mustBe200 = (response /*, z*/) => {
+const mustBe200 = (response, z, bundle) => {
   if (response.status !== 200) {
     throw new Error(`Unexpected status code ${response.status}`);
   }
   return response;
 };
 
-const autoParseJson = (response, z) => {
+const autoParseJson = (response, z, bundle) => {
   response.json = z.JSON.parse(response.content);
   return response;
 };
@@ -1748,7 +1733,7 @@ To manually print a log statement in your code, use `z.console.log`:
 z.console.log('Here are the input fields', bundle.inputData);
 ```
 
-The `z.console` object has all the same methods and works just like the Node.js [`Console`](https://nodejs.org/dist/latest-v4.x/docs/api/console.html) class - the only difference is we'll log to our distributed datastore and you can view them via `zapier logs` (more below).
+The `z.console` object has all the same methods and works just like the Node.js [`Console`](https://nodejs.org/docs/latest-v6.x/api/console.html) class - the only difference is we'll log to our distributed datastore and you can view them via `zapier logs` (more below).
 
 ### Viewing Console Logs
 
@@ -1985,7 +1970,18 @@ zapier test
 
 ### Testing & Environment Variables
 
-These work much like normal environment variables - for example:
+The best way to store sensitive values (like API keys, OAuth secrets, or passwords) is in an `.environment` file ([learn more](https://github.com/motdotla/dotenv#faq)). Then, you can include the following before your tests run:
+
+```js
+const zapier = require('zapier-platform-core');
+zapier.tools.env.inject(); // inject() can take a filename; defaults to ".environment"
+
+// now process.env has all the values in your .environment file
+```
+
+> Remember: don't add your secrets file to version control!
+
+Additionally, you can provide them dynamically at runtime:
 
 ```bash
 CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -2115,6 +2111,10 @@ See [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/Example-Apps) 
 
 ## FAQs
 
+*Q: Why doesn't Zapier support newer versions of Node.js?*
+
+A: We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) of Node (the latest of which is `v6.10.2`. As that updates, so too will we.
+
 *Q: Does Zapier support XML (SOAP) APIs?*
 
 A: Not natively, but it can! Users have reported that the following `npm` modules are compatible with the CLI Platform:
@@ -2238,6 +2238,82 @@ module.exports = {
 };
 
 ```
+
+*Q: How do I manually set the Node.js version to run my app with?*
+
+A: Update your `zapier-platform-core` dependency in `package.json`.  Each major version ties to a specific version of Node.js. You can find the mapping [here](https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js). We only support the version(s) supported by [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).
+
+*Q: How do search-powered fields relate to dynamic dropdowns and why are they both required together?*
+
+To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.
+
+When users are selecting specific resources (for instance, a Google Sheet), it's important they're able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via `id` instead. Rather than directing the user copy and paste an id for every item they might encounter, there is the notion of a **dynamic dropdown**. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item's name:
+
+![](https://cdn.zapier.com/storage/photos/fb56bdc2aab91504be0e51800bec4d64.png)
+
+The field's value reaches your app as an id. You define this connection with the `dynamic` property, which is a string: `trigger_key.id_key.label_key`. This approach works great if the user setting up the Zap always wants the Zap to use the same spreadsheet. They specify the id during setup and the Zap runs happily.
+
+**Search fields** take this connection a step further. Rather than set the spreadsheet id at setup, the user could precede the action with a search field to make the id dynamic. For instance, let's say you have a different spreadsheet for every day of the week. You could build the following zap:
+
+1. Some Trigger
+2. Calculate what day of the week it is today (Code)
+3. Find the spreadsheet that matches the day from Step 2
+4. Update the spreadsheet (with the id from step 3) with some data
+
+If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying `search` as a `search_key.id_key`. When paired **with a dynamic dropdown**, this will add a button to the editor that will add the search step to the user's Zap and map the id field correctly.
+
+![](https://cdn.zapier.com/storage/photos/d263fd3a56cf8108cb89195163e7c9aa.png)
+
+This is paired most often with "update" actions, where a required parameter will be a resource id.
+
+<a id="paging"></a>
+
+*Q: What's the deal with pagination? When is it used and how does it work?*
+
+A: Paging is **only used when a trigger is part of a dynamic dropdown**. Depending on how many items exist and how many are returned in the first poll, it's possible that the resource the user is looking for isn't in the initial poll. If they hit the "see more" button, we'll increment the value of `bundle.meta.page` and poll again.
+
+Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a `start` parameter:
+
+```javascript
+const getList = (z, bundle) => {
+  const promise = z.request({
+    url: 'http://example.com/api/list.json',
+    params: {
+      limit: 100,
+      offset: 100 * bundle.meta.page
+    }
+  });
+  return promise.then((response) => response.json);
+};
+```
+
+Lastly, you need to set `canPaginate` to `true` in your polling definition (per the [schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema)).
+
+<a id="dedup"></a>
+
+*Q: How does deduplication work?*
+
+A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
+
+For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
+
+There's a more in-depth explanation [here](https://zapier.com/developer/documentation/v2/deduplication/).
+
+*Q: Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!*
+
+A: For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:
+
+```js
+// ...
+let items = z.JSON.parse(response.content).items;
+items.forEach(item => {
+  item.id = item.contactId;
+})
+
+return items;
+```
+
+
 
 ## Command Line Tab Completion
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 - [Using Transpilers](#using-transpilers)
 - [Example Apps](#example-apps)
 - [FAQs](#faqs)
+  * [Why doesn't Zapier support newer versions of Node.js?](#why-doesnt-zapier-support-newer-versions-of-nodejs)
+  * [Does Zapier support XML (SOAP) APIs?](#does-zapier-support-xml-soap-apis)
+  * [Is it possible to iterate over pages in a polling trigger?](#is-it-possible-to-iterate-over-pages-in-a-polling-trigger)
+  * [How do I manually set the Node.js version to run my app with?](#how-do-i-manually-set-the-nodejs-version-to-run-my-app-with)
+  * [How do search-powered fields relate to dynamic dropdowns and why are they both required together?](#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together)
+  * [What's the deal with pagination? When is it used and how does it work?](#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work)
+  * [How does deduplication work?](#how-does-deduplication-work)
+  * [Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!](#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field-i-didnt-have-to-do-that-in-the-web-builder)
 - [Command Line Tab Completion](#command-line-tab-completion)
   * [Zsh Completion Script](#zsh-completion-script)
   * [Bash Completion Script](#bash-completion-script)
@@ -2111,13 +2119,14 @@ See [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/Example-Apps) 
 
 ## FAQs
 
-*Q: Why doesn't Zapier support newer versions of Node.js?*
+### Why doesn't Zapier support newer versions of Node.js?
 
-A: We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) of Node (the latest of which is `v6.10.2`. As that updates, so too will we.
+We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) of Node (the latest of which is `v6.10.2`. As that updates, so too will we.
 
-*Q: Does Zapier support XML (SOAP) APIs?*
 
-A: Not natively, but it can! Users have reported that the following `npm` modules are compatible with the CLI Platform:
+### Does Zapier support XML (SOAP) APIs?
+
+Not natively, but it can! Users have reported that the following `npm` modules are compatible with the CLI Platform:
 
 * [pixl-xml](https://github.com/jhuckaby/pixl-xml)
 * [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js)
@@ -2139,9 +2148,9 @@ const App = {
 
 ```
 
-*Q: Is it possible to iterate over pages in a polling trigger?*
+### Is it possible to iterate over pages in a polling trigger?
 
-A: Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).
+Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).
 
 ```javascript
 // some async call
@@ -2239,11 +2248,11 @@ module.exports = {
 
 ```
 
-*Q: How do I manually set the Node.js version to run my app with?*
+### How do I manually set the Node.js version to run my app with?
 
-A: Update your `zapier-platform-core` dependency in `package.json`.  Each major version ties to a specific version of Node.js. You can find the mapping [here](https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js). We only support the version(s) supported by [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).
+Update your `zapier-platform-core` dependency in `package.json`.  Each major version ties to a specific version of Node.js. You can find the mapping [here](https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js). We only support the version(s) supported by [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).
 
-*Q: How do search-powered fields relate to dynamic dropdowns and why are they both required together?*
+### How do search-powered fields relate to dynamic dropdowns and why are they both required together?
 
 To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.
 
@@ -2267,10 +2276,9 @@ If the connection between steps 3 and 4 is a common one, you can indicate that i
 This is paired most often with "update" actions, where a required parameter will be a resource id.
 
 <a id="paging"></a>
+### What's the deal with pagination? When is it used and how does it work?
 
-*Q: What's the deal with pagination? When is it used and how does it work?*
-
-A: Paging is **only used when a trigger is part of a dynamic dropdown**. Depending on how many items exist and how many are returned in the first poll, it's possible that the resource the user is looking for isn't in the initial poll. If they hit the "see more" button, we'll increment the value of `bundle.meta.page` and poll again.
+Paging is **only used when a trigger is part of a dynamic dropdown**. Depending on how many items exist and how many are returned in the first poll, it's possible that the resource the user is looking for isn't in the initial poll. If they hit the "see more" button, we'll increment the value of `bundle.meta.page` and poll again.
 
 Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a `start` parameter:
 
@@ -2290,18 +2298,17 @@ const getList = (z, bundle) => {
 Lastly, you need to set `canPaginate` to `true` in your polling definition (per the [schema](https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema)).
 
 <a id="dedup"></a>
+### How does deduplication work?
 
-*Q: How does deduplication work?*
-
-A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
+Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the `id`s to all those we've seen before, trigger on new objects, and update the list of seen `id`s. When a Zap is turned on, we initialize the list of seen `id`s with a single poll. When it's turned off, we clear that list. For this reason, it's important that calls to a polling endpoint always return the newest items.
 
 For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
 
 There's a more in-depth explanation [here](https://zapier.com/developer/documentation/v2/deduplication/).
 
-*Q: Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!*
+### Why are my triggers complaining if I don't provide an explicit `id` field? I didn't have to do that in the Web Builder!
 
-A: For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:
+For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:
 
 ```js
 // ...

--- a/docs/index.html
+++ b/docs/index.html
@@ -348,7 +348,17 @@ a code {
 <li><a href="#using-npm-modules">Using <code>npm</code> Modules</a></li>
 <li><a href="#using-transpilers">Using Transpilers</a></li>
 <li><a href="#example-apps">Example Apps</a></li>
-<li><a href="#faqs">FAQs</a></li>
+<li><a href="#faqs">FAQs</a><ul>
+<li><a href="#why-doesnt-zapier-support-newer-versions-of-nodejs">Why doesn&#39;t Zapier support newer versions of Node.js?</a></li>
+<li><a href="#does-zapier-support-xml-soap-apis">Does Zapier support XML (SOAP) APIs?</a></li>
+<li><a href="#is-it-possible-to-iterate-over-pages-in-a-polling-trigger">Is it possible to iterate over pages in a polling trigger?</a></li>
+<li><a href="#how-do-i-manually-set-the-nodejs-version-to-run-my-app-with">How do I manually set the Node.js version to run my app with?</a></li>
+<li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
+<li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&#39;s the deal with pagination? When is it used and how does it work?</a></li>
+<li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field-i-didnt-have-to-do-that-in-the-web-builder">Why are my triggers complaining if I don&#39;t provide an explicit <code>id</code> field? I didn&#39;t have to do that in the Web Builder!</a></li>
+</ul>
+</li>
 <li><a href="#command-line-tab-completion">Command Line Tab Completion</a><ul>
 <li><a href="#zsh-completion-script">Zsh Completion Script</a></li>
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
@@ -524,7 +534,17 @@ a code {
 <li><a href="#using-npm-modules">Using <code>npm</code> Modules</a></li>
 <li><a href="#using-transpilers">Using Transpilers</a></li>
 <li><a href="#example-apps">Example Apps</a></li>
-<li><a href="#faqs">FAQs</a></li>
+<li><a href="#faqs">FAQs</a><ul>
+<li><a href="#why-doesnt-zapier-support-newer-versions-of-nodejs">Why doesn&apos;t Zapier support newer versions of Node.js?</a></li>
+<li><a href="#does-zapier-support-xml-soap-apis">Does Zapier support XML (SOAP) APIs?</a></li>
+<li><a href="#is-it-possible-to-iterate-over-pages-in-a-polling-trigger">Is it possible to iterate over pages in a polling trigger?</a></li>
+<li><a href="#how-do-i-manually-set-the-nodejs-version-to-run-my-app-with">How do I manually set the Node.js version to run my app with?</a></li>
+<li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
+<li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</a></li>
+<li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field-i-didnt-have-to-do-that-in-the-web-builder">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field? I didn&apos;t have to do that in the Web Builder!</a></li>
+</ul>
+</li>
 <li><a href="#command-line-tab-completion">Command Line Tab Completion</a><ul>
 <li><a href="#zsh-completion-script">Zsh Completion Script</a></li>
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
@@ -3709,7 +3729,34 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Q: Why doesn&apos;t Zapier support newer versions of Node.js?</em></p><p>A: We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">versions</a> of Node (the latest of which is <code>v6.10.2</code>. As that updates, so too will we.</p><p><em>Q: Does Zapier support XML (SOAP) APIs?</em></p><p>A: Not natively, but it can! Users have reported that the following <code>npm</code> modules are compatible with the CLI Platform:</p><ul>
+      <h3 id="why-doesnt-zapier-support-newer-versions-of-nodejs">Why doesn&apos;t Zapier support newer versions of Node.js?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">versions</a> of Node (the latest of which is <code>v6.10.2</code>. As that updates, so too will we.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="does-zapier-support-xml-soap-apis">Does Zapier support XML (SOAP) APIs?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Not natively, but it can! Users have reported that the following <code>npm</code> modules are compatible with the CLI Platform:</p><ul>
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
@@ -3734,7 +3781,16 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Q: Is it possible to iterate over pages in a polling trigger?</em></p><p>A: Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).</p>
+      <h3 id="is-it-possible-to-iterate-over-pages-in-a-polling-trigger">Is it possible to iterate over pages in a polling trigger?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Yes, though there are caveats. Your entire function only gets 30 seconds to run. HTTP requests are costly, so paging through a list may time out (which you should avoid at all costs).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-comment">// some async call</span>
@@ -3838,12 +3894,57 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Q: How do I manually set the Node.js version to run my app with?</em></p><p>A: Update your <code>zapier-platform-core</code> dependency in <code>package.json</code>.  Each major version ties to a specific version of Node.js. You can find the mapping <a href="https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js">here</a>. We only support the version(s) supported by <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">AWS Lambda</a>.</p><p><em>Q: How do search-powered fields relate to dynamic dropdowns and why are they both required together?</em></p><p>To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.</p><p>When users are selecting specific resources (for instance, a Google Sheet), it&apos;s important they&apos;re able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via <code>id</code> instead. Rather than directing the user copy and paste an id for every item they might encounter, there is the notion of a <strong>dynamic dropdown</strong>. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item&apos;s name:</p><p><img src="https://cdn.zapier.com/storage/photos/fb56bdc2aab91504be0e51800bec4d64.png" alt=""></p><p>The field&apos;s value reaches your app as an id. You define this connection with the <code>dynamic</code> property, which is a string: <code>trigger_key.id_key.label_key</code>. This approach works great if the user setting up the Zap always wants the Zap to use the same spreadsheet. They specify the id during setup and the Zap runs happily.</p><p><strong>Search fields</strong> take this connection a step further. Rather than set the spreadsheet id at setup, the user could precede the action with a search field to make the id dynamic. For instance, let&apos;s say you have a different spreadsheet for every day of the week. You could build the following zap:</p><ol>
+      <h3 id="how-do-i-manually-set-the-nodejs-version-to-run-my-app-with">How do I manually set the Node.js version to run my app with?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Update your <code>zapier-platform-core</code> dependency in <code>package.json</code>.  Each major version ties to a specific version of Node.js. You can find the mapping <a href="https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js">here</a>. We only support the version(s) supported by <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">AWS Lambda</a>.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.</p><p>When users are selecting specific resources (for instance, a Google Sheet), it&apos;s important they&apos;re able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via <code>id</code> instead. Rather than directing the user copy and paste an id for every item they might encounter, there is the notion of a <strong>dynamic dropdown</strong>. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item&apos;s name:</p><p><img src="https://cdn.zapier.com/storage/photos/fb56bdc2aab91504be0e51800bec4d64.png" alt=""></p><p>The field&apos;s value reaches your app as an id. You define this connection with the <code>dynamic</code> property, which is a string: <code>trigger_key.id_key.label_key</code>. This approach works great if the user setting up the Zap always wants the Zap to use the same spreadsheet. They specify the id during setup and the Zap runs happily.</p><p><strong>Search fields</strong> take this connection a step further. Rather than set the spreadsheet id at setup, the user could precede the action with a search field to make the id dynamic. For instance, let&apos;s say you have a different spreadsheet for every day of the week. You could build the following zap:</p><ol>
 <li>Some Trigger</li>
 <li>Calculate what day of the week it is today (Code)</li>
 <li>Find the spreadsheet that matches the day from Step 2</li>
 <li>Update the spreadsheet (with the id from step 3) with some data</li>
-</ol><p>If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying <code>search</code> as a <code>search_key.id_key</code>. When paired <strong>with a dynamic dropdown</strong>, this will add a button to the editor that will add the search step to the user&apos;s Zap and map the id field correctly.</p><p><img src="https://cdn.zapier.com/storage/photos/d263fd3a56cf8108cb89195163e7c9aa.png" alt=""></p><p>This is paired most often with &quot;update&quot; actions, where a required parameter will be a resource id.</p><p><a id="paging"></a></p><p><em>Q: What&apos;s the deal with pagination? When is it used and how does it work?</em></p><p>A: Paging is <strong>only used when a trigger is part of a dynamic dropdown</strong>. Depending on how many items exist and how many are returned in the first poll, it&apos;s possible that the resource the user is looking for isn&apos;t in the initial poll. If they hit the &quot;see more&quot; button, we&apos;ll increment the value of <code>bundle.meta.page</code> and poll again.</p><p>Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a <code>start</code> parameter:</p>
+</ol><p>If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying <code>search</code> as a <code>search_key.id_key</code>. When paired <strong>with a dynamic dropdown</strong>, this will add a button to the editor that will add the search step to the user&apos;s Zap and map the id field correctly.</p><p><img src="https://cdn.zapier.com/storage/photos/d263fd3a56cf8108cb89195163e7c9aa.png" alt=""></p><p>This is paired most often with &quot;update&quot; actions, where a required parameter will be a resource id.</p><p><a id="paging"></a></p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Paging is <strong>only used when a trigger is part of a dynamic dropdown</strong>. Depending on how many items exist and how many are returned in the first poll, it&apos;s possible that the resource the user is looking for isn&apos;t in the initial poll. If they hit the &quot;see more&quot; button, we&apos;ll increment the value of <code>bundle.meta.page</code> and poll again.</p><p>Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a <code>start</code> parameter:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> getList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
@@ -3862,7 +3963,43 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Lastly, you need to set <code>canPaginate</code> to <code>true</code> in your polling definition (per the <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema">schema</a>).</p><p><a id="dedup"></a></p><p><em>Q: How does deduplication work?</em></p><p>A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://zapier.com/developer/documentation/v2/deduplication/">here</a>.</p><p><em>Q: Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field? I didn&apos;t have to do that in the Web Builder!</em></p><p>A: For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if <code>id</code> wasn&apos;t present. In order to ensure we don&apos;t guess wrong, we now require that the developers send us an <code>id</code> field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:</p>
+      <p>Lastly, you need to set <code>canPaginate</code> to <code>true</code> in your polling definition (per the <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema">schema</a>).</p><p><a id="dedup"></a></p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="how-does-deduplication-work">How does deduplication work?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://zapier.com/developer/documentation/v2/deduplication/">here</a>.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field-i-didnt-have-to-do-that-in-the-web-builder">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field? I didn&apos;t have to do that in the Web Builder!</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if <code>id</code> wasn&apos;t present. In order to ensure we don&apos;t guess wrong, we now require that the developers send us an <code>id</code> field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2194,8 +2194,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript">{
-  <span class="hljs-attr">createdBy</span>: <span class="hljs-string">&apos;Bobby Flay&apos;</span>
-  style: <span class="hljs-string">&apos;mediterranean&apos;</span>
+  <span class="hljs-attr">createdBy</span>: <span class="hljs-string">&apos;his name is Bobby Flay&apos;</span>
+  style: <span class="hljs-string">&apos;he cooks mediterranean&apos;</span>
 }
 </code></pre>
     </div>
@@ -2216,10 +2216,21 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript">{
-  <span class="hljs-attr">createdBy</span>: <span class="hljs-string">&apos;{{chef_name}}&apos;</span>
-  style: <span class="hljs-string">&apos;{{style}}&apos;</span>
+  <span class="hljs-attr">createdBy</span>: <span class="hljs-string">&apos;his name is {{123__chef_name}}&apos;</span>
+  style: <span class="hljs-string">&apos;he cooks {{456__style}}&apos;</span>
 }
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>&quot;curlies&quot; are data mapped in from previous steps. They take the form <code>{{NODE_ID__key_name}}</code>. You&apos;ll usually want to use <code>bundle.inputData</code> instead.</p>
+</blockquote>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -2234,39 +2245,69 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><code>bundle.meta</code> is extra information useful for doing advanced behaviors depending on what the user is doing. It looks something like this:</p>
+      <p><code>bundle.meta</code> is extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:</p>
     </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-javascript">{
-  <span class="hljs-attr">frontend</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">prefill</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">hydrate</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">test_poll</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">standard_poll</span>: <span class="hljs-literal">true</span>,
-  <span class="hljs-attr">first_poll</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">limit</span>: <span class="hljs-number">-1</span>,
-  <span class="hljs-attr">page</span>: <span class="hljs-number">0</span>,
-}
-</code></pre>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For example - if you want to do pagination - you could do:</p>
+      <table>
+<thead>
+<tr>
+<th>key</th>
+<th>default</th>
+<th>description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>frontend</td>
+<td><code>false</code></td>
+<td>if true, this run was initiated manually via the Zap editor</td>
+</tr>
+<tr>
+<td>prefill</td>
+<td><code>false</code></td>
+<td>if true, this poll is being used to populate a dynamic dropdown</td>
+</tr>
+<tr>
+<td>hydrate</td>
+<td><code>true</code></td>
+<td>if true, the results of this run will be hydrated (false if we&apos;re in the middle of hydrating already)</td>
+</tr>
+<tr>
+<td>test_poll</td>
+<td><code>false</code></td>
+<td>if true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> on the auth</td>
+</tr>
+<tr>
+<td>standard_poll</td>
+<td><code>true</code></td>
+<td>the opposite of <code>test_poll</code></td>
+</tr>
+<tr>
+<td>first_poll</td>
+<td><code>false</code></td>
+<td>if true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. See: <a href="#dedup">deduplication</a></td>
+</tr>
+<tr>
+<td>limit</td>
+<td><code>-1</code></td>
+<td>the number of items to fetch. <code>-1</code> indicates there&apos;s no limit (which will almost always be the case)</td>
+</tr>
+<tr>
+<td>page</td>
+<td><code>0</code></td>
+<td>used in <a href="#paging">paging</a> to uniquely identify which page of results should be returned</td>
+</tr>
+</tbody>
+</table>
     </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> getList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
-  <span class="hljs-keyword">const</span> promise = z.request({
-    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;http://example.com/api/list.json&apos;</span>,
-    <span class="hljs-attr">params</span>: {
-      <span class="hljs-attr">limit</span>: <span class="hljs-number">100</span>,
-      <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
-    }
-  });
-  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
-};
-</code></pre>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -2467,7 +2508,7 @@ zapier env 1.0.0
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>There are two primary ways to make HTTP requests in the Zapier platform:</p><ol>
 <li><strong>Shorthand HTTP Requests</strong> - these are simple object literals that make it easy to define simple requests.</li>
-<li><strong>Manual HTTP Requests</strong> - this is much less &quot;magic&quot;, you use <code>z.request([url], options)</code> to make the requests and control the response.</li>
+<li><strong>Manual HTTP Requests</strong> - you use <code>z.request([url], options)</code> to make the requests and control the response. Use this when you need to change options for certain requests (for all requests, use middleware).</li>
 </ol><p>There are also a few helper constructs you can use to reduce boilerplate:</p><ol>
 <li><code>requestTemplate</code> which is an shorthand HTTP request that will be merged with every request.</li>
 <li><code>beforeRequest</code> middleware which is an array of functions to mutate a request before it is sent.</li>
@@ -2660,19 +2701,19 @@ zapier env 1.0.0
 </blockquote><p>Try putting them in your app definition:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> addHeader = <span class="hljs-function">(<span class="hljs-params">request <span class="hljs-regexp">/*, z*/</span></span>) =&gt;</span> {
+      <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> addHeader = <span class="hljs-function">(<span class="hljs-params">request, z, bundle</span>) =&gt;</span> {
   request.headers[<span class="hljs-string">&apos;my-header&apos;</span>] = <span class="hljs-string">&apos;from zapier&apos;</span>;
   <span class="hljs-keyword">return</span> request;
 };
 
-<span class="hljs-keyword">const</span> mustBe200 = <span class="hljs-function">(<span class="hljs-params">response <span class="hljs-regexp">/*, z*/</span></span>) =&gt;</span> {
+<span class="hljs-keyword">const</span> mustBe200 = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">if</span> (response.status !== <span class="hljs-number">200</span>) {
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">`Unexpected status code <span class="hljs-subst">${response.status}</span>`</span>);
   }
   <span class="hljs-keyword">return</span> response;
 };
 
-<span class="hljs-keyword">const</span> autoParseJson = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
+<span class="hljs-keyword">const</span> autoParseJson = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
   response.json = z.JSON.parse(response.content);
   <span class="hljs-keyword">return</span> response;
 };
@@ -3025,7 +3066,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The <code>z.console</code> object has all the same methods and works just like the Node.js <a href="https://nodejs.org/dist/latest-v4.x/docs/api/console.html"><code>Console</code></a> class - the only difference is we&apos;ll log to our distributed datastore and you can view them via <code>zapier logs</code> (more below).</p>
+      <p>The <code>z.console</code> object has all the same methods and works just like the Node.js <a href="https://nodejs.org/docs/latest-v6.x/api/console.html"><code>Console</code></a> class - the only difference is we&apos;ll log to our distributed datastore and you can view them via <code>zapier logs</code> (more below).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3411,7 +3452,22 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>These work much like normal environment variables - for example:</p>
+      <p>The best way to store sensitive values (like API keys, OAuth secrets, or passwords) is in an <code>.environment</code> file (<a href="https://github.com/motdotla/dotenv#faq">learn more</a>). Then, you can include the following before your tests run:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> zapier = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;zapier-platform-core&apos;</span>);
+zapier.tools.env.inject(); <span class="hljs-comment">// inject() can take a filename; defaults to &quot;.environment&quot;</span>
+
+<span class="hljs-comment">// now process.env has all the values in your .environment file</span>
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Remember: don&apos;t add your secrets file to version control!</p>
+</blockquote><p>Additionally, you can provide them dynamically at runtime:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</span>
@@ -3653,7 +3709,7 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Q: Does Zapier support XML (SOAP) APIs?</em></p><p>A: Not natively, but it can! Users have reported that the following <code>npm</code> modules are compatible with the CLI Platform:</p><ul>
+      <p><em>Q: Why doesn&apos;t Zapier support newer versions of Node.js?</em></p><p>A: We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">versions</a> of Node (the latest of which is <code>v6.10.2</code>. As that updates, so too will we.</p><p><em>Q: Does Zapier support XML (SOAP) APIs?</em></p><p>A: Not natively, but it can! Users have reported that the following <code>npm</code> modules are compatible with the CLI Platform:</p><ul>
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
@@ -3776,6 +3832,46 @@ npm run zapier-push
     }
   }
 };
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p><em>Q: How do I manually set the Node.js version to run my app with?</em></p><p>A: Update your <code>zapier-platform-core</code> dependency in <code>package.json</code>.  Each major version ties to a specific version of Node.js. You can find the mapping <a href="https://github.com/zapier/zapier-platform-cli/blob/master/src/version-store.js">here</a>. We only support the version(s) supported by <a href="https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html">AWS Lambda</a>.</p><p><em>Q: How do search-powered fields relate to dynamic dropdowns and why are they both required together?</em></p><p>To understand search-powered fields, we have to have a good understanding of dynamic dropdowns.</p><p>When users are selecting specific resources (for instance, a Google Sheet), it&apos;s important they&apos;re able to select the exact sheet they want. Instead of referencing the sheet by name (which may change), we match via <code>id</code> instead. Rather than directing the user copy and paste an id for every item they might encounter, there is the notion of a <strong>dynamic dropdown</strong>. A dropdown is a trigger that returns a list of resources. It can pull double duty and use its results to power another trigger, search, or action in the same app.  It provides a list of ids with labels that show the item&apos;s name:</p><p><img src="https://cdn.zapier.com/storage/photos/fb56bdc2aab91504be0e51800bec4d64.png" alt=""></p><p>The field&apos;s value reaches your app as an id. You define this connection with the <code>dynamic</code> property, which is a string: <code>trigger_key.id_key.label_key</code>. This approach works great if the user setting up the Zap always wants the Zap to use the same spreadsheet. They specify the id during setup and the Zap runs happily.</p><p><strong>Search fields</strong> take this connection a step further. Rather than set the spreadsheet id at setup, the user could precede the action with a search field to make the id dynamic. For instance, let&apos;s say you have a different spreadsheet for every day of the week. You could build the following zap:</p><ol>
+<li>Some Trigger</li>
+<li>Calculate what day of the week it is today (Code)</li>
+<li>Find the spreadsheet that matches the day from Step 2</li>
+<li>Update the spreadsheet (with the id from step 3) with some data</li>
+</ol><p>If the connection between steps 3 and 4 is a common one, you can indicate that in your field by specifying <code>search</code> as a <code>search_key.id_key</code>. When paired <strong>with a dynamic dropdown</strong>, this will add a button to the editor that will add the search step to the user&apos;s Zap and map the id field correctly.</p><p><img src="https://cdn.zapier.com/storage/photos/d263fd3a56cf8108cb89195163e7c9aa.png" alt=""></p><p>This is paired most often with &quot;update&quot; actions, where a required parameter will be a resource id.</p><p><a id="paging"></a></p><p><em>Q: What&apos;s the deal with pagination? When is it used and how does it work?</em></p><p>A: Paging is <strong>only used when a trigger is part of a dynamic dropdown</strong>. Depending on how many items exist and how many are returned in the first poll, it&apos;s possible that the resource the user is looking for isn&apos;t in the initial poll. If they hit the &quot;see more&quot; button, we&apos;ll increment the value of <code>bundle.meta.page</code> and poll again.</p><p>Paging is a lot like a regular trigger except the range of items returned is dynamic. The most common example of this is when you can pass a <code>start</code> parameter:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-javascript"><span class="hljs-keyword">const</span> getList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
+  <span class="hljs-keyword">const</span> promise = z.request({
+    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;http://example.com/api/list.json&apos;</span>,
+    <span class="hljs-attr">params</span>: {
+      <span class="hljs-attr">limit</span>: <span class="hljs-number">100</span>,
+      <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
+    }
+  });
+  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Lastly, you need to set <code>canPaginate</code> to <code>true</code> in your polling definition (per the <a href="https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#basicpollingoperationschema">schema</a>).</p><p><a id="dedup"></a></p><p><em>Q: How does deduplication work?</em></p><p>A: Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://zapier.com/developer/documentation/v2/deduplication/">here</a>.</p><p><em>Q: Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field? I didn&apos;t have to do that in the Web Builder!</em></p><p>A: For deduplication to work, we need to be able to identify and use a unique field. For WB apps, we guessed if <code>id</code> wasn&apos;t present. In order to ensure we don&apos;t guess wrong, we now require that the developers send us an <code>id</code> field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
+<span class="hljs-keyword">let</span> items = z.JSON.parse(response.content).items;
+items.forEach(<span class="hljs-function"><span class="hljs-params">item</span> =&gt;</span> {
+  item.id = item.contactId;
+})
+
+<span class="hljs-keyword">return</span> items;
 </code></pre>
     </div>
   </div>

--- a/snippets/middleware.js
+++ b/snippets/middleware.js
@@ -1,16 +1,16 @@
-const addHeader = (request /*, z*/) => {
+const addHeader = (request, z, bundle) => {
   request.headers['my-header'] = 'from zapier';
   return request;
 };
 
-const mustBe200 = (response /*, z*/) => {
+const mustBe200 = (response, z, bundle) => {
   if (response.status !== 200) {
     throw new Error(`Unexpected status code ${response.status}`);
   }
   return response;
 };
 
-const autoParseJson = (response, z) => {
+const autoParseJson = (response, z, bundle) => {
   response.json = z.JSON.parse(response.content);
   return response;
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -21,6 +21,7 @@ const { localAppCommand } = require('./local');
 const readCredentials = (credentials, explodeIfMissing = true) => {
   return Promise.resolve(
     credentials ||
+      // deploy key? ||
       readFile(constants.AUTH_LOCATION, 'Please run `zapier login`.')
         .then(buf => {
           return JSON.parse(buf.toString());


### PR DESCRIPTION
Some general changes and adding more examples. I'll run docs once it's 👍 to keep the PR a little cleaner. 

@bcooksey if you've got a sec, i'm a little foggy on how correct I am with what exactly the keys in `bundle.meta` do. I copied from [here](https://zapier.com/developer/documentation/v2/scripting/#extra-request-info-via-bundlemeta), but I remember some weirdness about the distinction between UI test vs auth test (or if that's relevant in CLI). Anecdotally, I had some test polls today that didn't set the flags I'd expect, so I'd like to set the record straight. Also, i'm super unclear on what `bundle.meta.limit` is and when it's relevant.

For [PDE-33](https://zapierorg.atlassian.net/browse/PDE-33). Fixes #131, fixes #164 