### PR TITLE
zapier convert: Escape them all!

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -559,6 +559,67 @@ const getSessionKey = (z, bundle) => {
           content.should.containEql("description: 'Finds a example.'");
         });
     });
+
+    it('should escape trigger label and description', () => {
+      const wbDef = {
+        triggers: {
+          example: {
+            label: "Ender's Trigger",
+            help_text: "It's a trigger.\nLine 2."
+          }
+        }
+      };
+      const stepDef = wbDef.triggers.example;
+
+      return convert
+        .renderStep('trigger', stepDef, 'example', wbDef)
+        .then(content => {
+          content.should.containEql('label: "Ender\'s Trigger"');
+          content.should.containEql(
+            'description: "It\'s a trigger.\\nLine 2."'
+          );
+        });
+    });
+
+    it('should escape create label and description', () => {
+      const wbDef = {
+        actions: {
+          example: {
+            label: "Ender's Action",
+            help_text: "It's an action.\nLine 2."
+          }
+        }
+      };
+      const stepDef = wbDef.actions.example;
+
+      return convert
+        .renderStep('create', stepDef, 'example', wbDef)
+        .then(content => {
+          content.should.containEql('label: "Ender\'s Action"');
+          content.should.containEql(
+            'description: "It\'s an action.\\nLine 2."'
+          );
+        });
+    });
+
+    it('should escape search label and description', () => {
+      const wbDef = {
+        searches: {
+          example: {
+            label: "Ender's Search",
+            help_text: "It's a search.\nLine 2."
+          }
+        }
+      };
+      const stepDef = wbDef.searches.example;
+
+      return convert
+        .renderStep('search', stepDef, 'example', wbDef)
+        .then(content => {
+          content.should.containEql('label: "Ender\'s Search"');
+          content.should.containEql('description: "It\'s a search.\\nLine 2."');
+        });
+    });
   });
 
   describe('render sample', () => {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -129,7 +129,9 @@ const renderField = (definition, key, indent = 0) => {
 
   props.push(renderProp('key', quote(key)));
   if (definition.label) {
-    props.push(renderProp('label', quote(escapeSpecialChars(definition.label))));
+    props.push(
+      renderProp('label', quote(escapeSpecialChars(definition.label)))
+    );
   }
 
   if (definition.help_text) {
@@ -243,7 +245,9 @@ const renderAuthTemplate = (authType, definition) => {
 
   const testTriggerKey = getTestTriggerKey(definition);
   if (testTriggerKey) {
-    templateContext.TEST_TRIGGER_MODULE = `./triggers/${snakeCase(testTriggerKey)}`;
+    templateContext.TEST_TRIGGER_MODULE = `./triggers/${snakeCase(
+      testTriggerKey
+    )}`;
   } else {
     templateContext.TEST_TRIGGER_MODULE = '';
   }
@@ -667,10 +671,9 @@ const renderStep = (type, definition, key, legacyApp) => {
   const label = definition.label || `${stepVerbsMap[type]} ${noun}`;
 
   const lowerNoun = noun.toLowerCase();
-  let description =
+  const description =
     definition.help_text ||
     stepDescriptionTemplateMap[type]({ lowerNoun: lowerNoun });
-  description = description.replace(/'/g, "\\'");
 
   const hidden = Boolean(definition.hide);
   const important = Boolean(definition.important);
@@ -678,8 +681,8 @@ const renderStep = (type, definition, key, legacyApp) => {
   const templateContext = {
     KEY: snakeCase(key),
     NOUN: noun,
-    DESCRIPTION: description,
-    LABEL: label,
+    DESCRIPTION: escapeSpecialChars(description),
+    LABEL: escapeSpecialChars(label),
     HIDDEN: hidden,
     IMPORTANT: important,
     FIELDS: fields,
@@ -714,11 +717,18 @@ const renderStep = (type, definition, key, legacyApp) => {
       definition.custom_fields_result_url;
   }
 
-  if (type === 'create' && !stepMeta.hasPreScripting && !stepMeta.hasFullScripting) {
+  if (
+    type === 'create' &&
+    !stepMeta.hasPreScripting &&
+    !stepMeta.hasFullScripting
+  ) {
     // Exclude create fields that uncheck "Send to Action Endpoint URL in JSON body"
     // https://zapier.com/developer/documentation/v2/action-fields/#send-to-action-endpoint-url-in-json-body
     const fieldKeys = _.keys(definition.fields);
-    const excludeFieldKeys = _.filter(fieldKeys, k => !definition.fields[k].send_in_json);
+    const excludeFieldKeys = _.filter(
+      fieldKeys,
+      k => !definition.fields[k].send_in_json
+    );
     templateContext.excludeFieldKeys = excludeFieldKeys || null;
   }
 
@@ -798,7 +808,7 @@ const renderStepTest = (type, definition, key, legacyApp) => {
   const inputData = renderDefaultInputData(definition);
   const templateContext = {
     KEY: key,
-    LABEL: label,
+    LABEL: escapeSpecialChars(label),
     AUTH_DATA: authData,
     INPUT_DATA: inputData
   };
@@ -833,7 +843,7 @@ const writeUtils = newAppDir => {
   );
 };
 
-const findSearchOrCreates = (legacyApp) => {
+const findSearchOrCreates = legacyApp => {
   let searchOrCreates = {};
   _.each(legacyApp.searches, (searchDef, searchKey) => {
     if (searchDef.action_pair_key) {
@@ -903,7 +913,11 @@ const renderIndex = legacyApp => {
     if (_.isEmpty(searchOrCreates)) {
       templateContext.SEARCH_OR_CREATES = null;
     } else {
-      templateContext.SEARCH_OR_CREATES = JSON.stringify(searchOrCreates, null, 2);
+      templateContext.SEARCH_OR_CREATES = JSON.stringify(
+        searchOrCreates,
+        null,
+        2
+      );
     }
 
     const templateFile = path.join(TEMPLATE_DIR, '/index.template.js');


### PR DESCRIPTION
All labels and descriptions should be escaped.

cc @avelis from https://github.com/zapier/zapier-platform-cli/commit/57119a2dd50f95e218e01620ebcdfeaea8579b88#commitcomment-27376147