### PR TITLE
zapier convert: Don't send OAuth access token when requesting access token

### DIFF
--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -43,9 +43,9 @@ if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <% }
 
 if (before && oauth) { %>const maybeIncludeAuth = (request, z, bundle) => {
-
-  request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
-
+  if (bundle.authData.access_token) {
+    request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+  }
   return request;
 };
 <% }

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -373,8 +373,9 @@ const getSessionKey = (z, bundle) => {
 
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
-
+  if (bundle.authData.access_token) {
+    request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
+  }
   return request;
 };
 `);
@@ -494,8 +495,9 @@ const getSessionKey = (z, bundle) => {
 
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
-
+  if (bundle.authData.access_token) {
+    request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
+  }
   return request;
 };
 `);


### PR DESCRIPTION
In a converted app that uses OAuth, `Authorization: Bearer undefined` header was sent when requesting an access token. Should change `maybeIncludeAuth` function so that it doesn't send that header when the access token doesn't exist yet.