### PR TITLE
be more specific when we cry invalid install

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,6 +22,7 @@ const nodeVersion = semver.Comparator(
   versionStore[versionStore.length - 1].nodeVersion
 ).semver.version;
 const LAMBDA_VERSION = `v${nodeVersion}`;
+const PACKAGE_VERSION = require('../package.json').version;
 
 const ART = `\
                 zzzzzzzz
@@ -56,6 +57,7 @@ module.exports = {
   DEFINITION_PATH,
   ENDPOINT,
   LAMBDA_VERSION,
+  PACKAGE_VERSION,
   PLATFORM_PACKAGE,
   STARTER_REPO
 };

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const colors = require('colors/safe');
 const updateNotifier = require('update-notifier');
 
-const { DEBUG, PLATFORM_PACKAGE } = require('./constants');
+const { DEBUG } = require('./constants');
 const commands = require('./commands');
 const utils = require('./utils');
 
@@ -79,12 +79,9 @@ module.exports = argv => {
     return;
   }
 
-  if (!utils.isValidAppInstall(command)) {
-    console.error(
-      colors.red(
-        `Looks like your package.json is missing \`${PLATFORM_PACKAGE}\`, its not restricted to a single version, or you haven't run npm install yet!`
-      )
-    );
+  const { valid, reason } = utils.isValidAppInstall(command);
+  if (!valid) {
+    console.error(colors.red(reason));
     process.exit(1);
   }
 

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -5,6 +5,7 @@ const colors = require('colors/safe');
 const path = require('path');
 const fse = require('fs-extra');
 const os = require('os');
+const semver = require('semver');
 
 const { PLATFORM_PACKAGE } = require('../constants');
 
@@ -89,7 +90,7 @@ const isValidNodeVersion = () => {
 
 const isValidAppInstall = command => {
   if (['help', 'init', 'login', 'apps', 'convert'].includes(command)) {
-    return true;
+    return { valid: true };
   }
 
   let packageJson;
@@ -97,31 +98,38 @@ const isValidAppInstall = command => {
     packageJson = require(path.join(process.cwd(), 'package.json'));
     const coreVersion = packageJson.dependencies[PLATFORM_PACKAGE];
     // could check for a lot more, but this is probably enough: https://docs.npmjs.com/files/package.json#dependencies
-    if (!coreVersion || coreVersion.includes('^')) {
-      return false;
+    if (!coreVersion) {
+      return {
+        valid: false,
+        reason: `Your app must depend on ${PLATFORM_PACKAGE}`
+      };
+    } else if (!semver.valid(coreVersion)) {
+      // semver.valid only matches single versions
+      return {
+        valid: false,
+        reason: `Your app must depend on an exact version of ${PLATFORM_PACKAGE}. Found "${coreVersion}" instead`
+      };
     }
   } catch (err) {
-    return false;
+    return { valid: false, reason: String(err) };
   }
 
   // try skipping the CLI itself
   const CLIpackageJson = require(path.join(__dirname, '../../package.json'));
   if (_.isEqual(packageJson, CLIpackageJson)) {
-    return true;
-  }
-
-  const dependencies = packageJson.dependencies || {};
-  if (!dependencies[PLATFORM_PACKAGE]) {
-    return false;
+    return { valid: true };
   }
 
   try {
-    require(`${process.cwd()}/node_modules/${PLATFORM_PACKAGE}`);
+    require(path.join(process.cwd(), 'node_modules', PLATFORM_PACKAGE));
   } catch (err) {
-    return false;
+    return {
+      valid: false,
+      reason: `Unable to find contents of ${PLATFORM_PACKAGE}, run \`npm install\``
+    };
   }
 
-  return true;
+  return { valid: true };
 };
 
 const npmInstall = appDir => {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -7,7 +7,7 @@ const fse = require('fs-extra');
 const os = require('os');
 const semver = require('semver');
 
-const { PLATFORM_PACKAGE } = require('../constants');
+const { PLATFORM_PACKAGE, PACKAGE_VERSION } = require('../constants');
 
 const camelCase = str => _.capitalize(_.camelCase(str));
 const snakeCase = str => _.snakeCase(str);
@@ -101,23 +101,17 @@ const isValidAppInstall = command => {
     if (!coreVersion) {
       return {
         valid: false,
-        reason: `Your app must depend on ${PLATFORM_PACKAGE}`
+        reason: `Your app doesn't depend on ${PLATFORM_PACKAGE}. Run \`npm install -E ${PLATFORM_PACKAGE}\` to resolve`
       };
     } else if (!semver.valid(coreVersion)) {
       // semver.valid only matches single versions
       return {
         valid: false,
-        reason: `Your app must depend on an exact version of ${PLATFORM_PACKAGE}. Found "${coreVersion}" instead`
+        reason: `Your app must depend on an exact version of ${PLATFORM_PACKAGE}. Instead of "${coreVersion}", specify an exact version (such as "${PACKAGE_VERSION}")`
       };
     }
   } catch (err) {
     return { valid: false, reason: String(err) };
-  }
-
-  // try skipping the CLI itself
-  const CLIpackageJson = require(path.join(__dirname, '../../package.json'));
-  if (_.isEqual(packageJson, CLIpackageJson)) {
-    return { valid: true };
   }
 
   try {
@@ -125,7 +119,7 @@ const isValidAppInstall = command => {
   } catch (err) {
     return {
       valid: false,
-      reason: `Unable to find contents of ${PLATFORM_PACKAGE}, run \`npm install\``
+      reason: `Looks like you're missing a local installaction of ${PLATFORM_PACKAGE}. Run \`npm install\` to resolve`
     };
   }
 


### PR DESCRIPTION
Fixes [PDE-69](https://zapierorg.atlassian.net/browse/PDE-69). the only part of this I wasn't sure on was the purpose of the following [blurb](https://github.com/zapier/zapier-platform-cli/blob/master/src/utils/misc.js#L107-L111) from @bryanhelmig:

```js
// try skipping the CLI itself
const CLIpackageJson = require(path.join(__dirname, '../../package.json'));
if (_.isEqual(packageJson, CLIpackageJson)) {
  return true;
}
```

As far as I can tell, this isn't needed anymore (it's only true if the command is run from within the `platform-cli` directory itself?

Past that, just some nicer messages!