### PR TITLE
zapier convert: Add .environment file and instruction to edit it

### DIFF
--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -33,8 +33,12 @@ const convert = (context, appid, location) => {
   };
 
   return utils.initApp(context, location, createApp).then(() => {
+    context.line();
     context.line(
-      '\nFinished! You might need to `npm install` then try `zapier test`!'
+      `Finished! You may try \`npm install\` and then \`zapier test\` in "${location}" directory.`
+    );
+    context.line(
+      "Also, if your app has authentication, don't forget to edit the environment variables in the .environment file."
     );
   });
 };

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1014,6 +1014,9 @@ const renderEnvironment = definition => {
 
 const writeEnvironment = (legacyApp, newAppDir) => {
   const content = renderEnvironment(legacyApp);
+  if (!content) {
+    return Promise.resolve(null);
+  }
   return createFile(content, '.environment', newAppDir);
 };
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1004,6 +1004,19 @@ const writeScripting = (legacyApp, newAppDir) => {
   });
 };
 
+const renderEnvironment = definition => {
+  const lines = _.map(definition.auth_fields, (field, key) => {
+    const upperKey = key.toUpperCase();
+    return `${upperKey}=YOUR_${upperKey}`;
+  });
+  return lines.join('\n');
+};
+
+const writeEnvironment = (legacyApp, newAppDir) => {
+  const content = renderEnvironment(legacyApp);
+  return createFile(content, '.environment', newAppDir);
+};
+
 const writeGitIgnore = newAppDir => {
   const srcPath = path.join(TEMPLATE_DIR, '/gitignore');
   const destPath = path.join(newAppDir, '/.gitignore');
@@ -1028,6 +1041,7 @@ const convertApp = (legacyApp, newAppDir) => {
   promises.push(writeIndex(legacyApp, newAppDir));
   promises.push(writePackageJson(legacyApp, newAppDir));
   promises.push(writeScripting(legacyApp, newAppDir));
+  promises.push(writeEnvironment(legacyApp, newAppDir));
   promises.push(writeGitIgnore(newAppDir));
 
   if (hasAuth(legacyApp)) {


### PR DESCRIPTION
This PR generates a `.environment` file incluing all the auth fields and prints a message instructing users to edit `.environment` when the conversion is done.