### PR TITLE
Fix NaN error when running `zapier env`

### DIFF
--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -38,7 +38,8 @@ const env = (context, version, key, value) => {
         );
 
         // touch index.js to force watch to pick up env changes
-        fs.utimesSync(utils.entryPoint(), NaN, NaN);
+        const now = Date.now() / 1000;
+        fs.utimesSync(utils.entryPoint(), now, now);
 
         return;
       });


### PR DESCRIPTION
Fixes the following error when running `zapier env <VERSION> <VARNAME> <VALUE>` on Node 8.x:

```
Error: Cannot parse time: NaN
    at toUnixTimestamp (fs.js:1190:9)
    at Object.fs.utimesSync (fs.js:1212:11)
    at /Users/eliang/Projects/zapier-platform/cli/lib/commands/env.js:33:10
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

This was because `fs.utimesSync()` behaves differently on Node 8.x. Node 6.x allows you to pass `NaN` as `atime` and `mtime`, and it will automatically get converted to `Date.now() / 1000`, whereas Node 8.x raises an error. Related docs:

* https://nodejs.org/docs/latest-v8.x/api/fs.html#fs_fs_utimes_path_atime_mtime_callback
* https://nodejs.org/docs/latest-v6.x/api/fs.html#fs_fs_utimes_path_atime_mtime_callback