### PR TITLE
zapier convert: Don't require 'id' property in creates' tests

### DIFF
--- a/scaffold/convert/create-test.template.js
+++ b/scaffold/convert/create-test.template.js
@@ -17,9 +17,8 @@ describe('Creates - <%= LABEL %>', () => {
     };
 
     appTester(App.creates['<%= KEY %>'].operation.perform, bundle)
-      .then((result) => {
+      .then(result => {
         result.should.not.be.an.Array();
-        result.should.have.property('id');
         done();
       })
       .catch(done);


### PR DESCRIPTION
Removes the requirement of an `id` property in creates' test code.