### PR TITLE
zapier convert: Add track info in converted app's package.json

### DIFF
--- a/scaffold/convert/package.template.json
+++ b/scaffold/convert/package.template.json
@@ -18,5 +18,9 @@
     "mocha": "4.0.1",
     "should": "13.1.2"
   },
-  "private": true
+  "private": true,
+  "zapier": {
+    "convertedFromAppID": <%= APP_ID %>,
+    "convertedByCLIVersion": "<%= CLI_VERSION %>"
+  }
 }

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -26,6 +26,11 @@ const convert = (context, appid, location) => {
     return utils
       .callAPI(null, { url })
       .then(legacyApp => {
+        // The JSON dump of the app doesn't have app ID, let's add it here
+        legacyApp.general.app_id = appid;
+        return legacyApp;
+      })
+      .then(legacyApp => {
         utils.printDone();
         return legacyApp;
       })

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -673,4 +673,21 @@ const getSessionKey = (z, bundle) => {
       });
     });
   });
+
+  describe('render package.json', () => {
+    it('should render track info', () => {
+      const wbDef = {
+        general: {
+          title: 'Example App',
+          description: 'It\'s an "example" app.',
+          app_id: 1234
+        }
+      };
+      return convert.renderPackageJson(wbDef).then(content => {
+        const pkg = JSON.parse(content);
+        pkg.zapier.convertedFromAppID.should.eql(1234);
+        pkg.zapier.convertedByCLIVersion.should.be.ok();
+      });
+    });
+  });
 });

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -5,6 +5,7 @@ const stripComments = require('strip-comments');
 const { camelCase, snakeCase } = require('./misc');
 const { copyFile, readFile, writeFile, ensureDir } = require('./files');
 const { printStarting, printDone } = require('./display');
+const CLI_VERSION = require('../../package.json').version;
 
 const TEMPLATE_DIR = path.join(__dirname, '../../scaffold/convert');
 const ZAPIER_LEGACY_SCRIPTING_RUNNER_VERSION = '1.0.0';
@@ -936,7 +937,9 @@ const renderPackageJson = legacyApp => {
 
   const templateContext = {
     NAME: _.kebabCase(legacyApp.general.title),
-    DESCRIPTION: escapeSpecialChars(legacyApp.general.description)
+    DESCRIPTION: escapeSpecialChars(legacyApp.general.description),
+    APP_ID: legacyApp.general.app_id,
+    CLI_VERSION: CLI_VERSION
   };
 
   const zapierCoreVersion = require('../../package.json').version;

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -5,7 +5,7 @@ const stripComments = require('strip-comments');
 const { camelCase, snakeCase } = require('./misc');
 const { copyFile, readFile, writeFile, ensureDir } = require('./files');
 const { printStarting, printDone } = require('./display');
-const CLI_VERSION = require('../../package.json').version;
+const { PACKAGE_VERSION } = require('../constants');
 
 const TEMPLATE_DIR = path.join(__dirname, '../../scaffold/convert');
 const ZAPIER_LEGACY_SCRIPTING_RUNNER_VERSION = '1.0.0';
@@ -935,18 +935,21 @@ const writeIndex = (legacyApp, newAppDir) => {
 const renderPackageJson = legacyApp => {
   const { needsLegacyScriptingRunner } = getMetaData(legacyApp);
 
+  // Not using escapeSpecialChars because we don't want to escape single quotes (not allowed in JSON)
+  const description = legacyApp.general.description
+    .replace(/\n/g, '\\n')
+    .replace(/"/g, '\\"');
+
   const templateContext = {
     NAME: _.kebabCase(legacyApp.general.title),
-    DESCRIPTION: escapeSpecialChars(legacyApp.general.description),
+    DESCRIPTION: description,
     APP_ID: legacyApp.general.app_id,
-    CLI_VERSION: CLI_VERSION
+    CLI_VERSION: PACKAGE_VERSION
   };
-
-  const zapierCoreVersion = require('../../package.json').version;
 
   const dependencies = [];
 
-  dependencies.push(`"zapier-platform-core": "${zapierCoreVersion}"`);
+  dependencies.push(`"zapier-platform-core": "${PACKAGE_VERSION}"`);
 
   if (needsLegacyScriptingRunner) {
     // TODO: Make conditional
@@ -1071,5 +1074,6 @@ module.exports = {
   getHeader,
   getBeforeRequests,
   getAfterResponses,
-  hasAuth
+  hasAuth,
+  renderPackageJson
 };


### PR DESCRIPTION
Adds to custom fields to the converted app's `package.json`:

* `convertedFromAppID`: the source WB app which was being converted to CLI
* `convertedByCLIVersion`: the CLI version that was used to perform `zapier convert`

The two fields are nested in a field named `zapier`, which allows us to add any other custom fields in the future.