### PR TITLE
zapier convert: Add input fields to test code

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -16,8 +16,11 @@ const makeRequest = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preWriteEvent, z, bundle)
-    .then((preWriteResult) => z.request(preWriteResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preWriteResult => z.request(preWriteResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content)
+    });
 };
 <%
 }
@@ -37,8 +40,10 @@ const makeRequest = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preWriteEvent, z, bundle)
-    .then((preWriteResult) => z.request(preWriteResult))
-    .then((response) => {
+    .then(preWriteResult => z.request(preWriteResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_write() from scripting.
       const postWriteEvent = {
         name: 'create.post',
@@ -74,7 +79,9 @@ const makeRequest = (z, bundle) => {
     body: bundle.inputData
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_write() from scripting.
       const postWriteEvent = {
         name: 'create.post',
@@ -125,8 +132,10 @@ const makeRequest = (z, bundle) => {
     method: 'POST',
     body: bundle.inputData
   });
-  return responsePromise
-    .then(response => z.JSON.parse(response.content));
+  return responsePromise.then(response => {
+    response.throwForStatus();
+    return z.JSON.parse(response.content);
+  });
 };
 <% }
 
@@ -159,8 +168,11 @@ const getInputFields = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
-    .then((preFieldsResult) => z.request(preFieldsResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preFieldsResult => z.request(preFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } else if (inputFieldPreScripting && inputFieldPostScripting) { %>
 const getInputFields = (z, bundle) => {
@@ -176,13 +188,15 @@ const getInputFields = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
-    .then((preFieldsResult) => z.request(preFieldsResult))
-    .then((response) => {
+    .then(preFieldsResult => z.request(preFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_action_fields() from scripting.
       const postFieldsEvent = {
         name: 'create.input.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
     });
@@ -199,12 +213,14 @@ const getInputFields = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_action_fields() from scripting.
       const postFieldsEvent = {
         name: 'create.input.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
     });
@@ -217,8 +233,10 @@ const getInputFields = (z, bundle) => {
   const responsePromise = z.request({
     url: url
   });
-  return responsePromise
-    .then((response) => z.JSON.parse(response.content));
+  return responsePromise.then(response => {
+    response.throwForStatus();
+    return z.JSON.parse(response.content);
+  });
 };
 <% }
 
@@ -233,7 +251,7 @@ const getOutputFields = (z, bundle) => {
   // Do a _custom_action_result_fields() from scripting.
   const fullResultFieldsEvent = {
     name: 'create.output',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
 };
@@ -248,11 +266,14 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'create.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } else if (outputFieldPreScripting && outputFieldPostScripting) { %>
 const getOutputFields = (z, bundle) => {
@@ -265,16 +286,18 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'create.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => {
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_action_result_fields() from scripting.
       const postResultFieldsEvent = {
         name: 'create.output.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
     });
@@ -290,16 +313,17 @@ const getOutputFields = (z, bundle) => {
   const responsePromise = z.request({
     url: bundle._legacyUrl
   });
-  return responsePromise
-    .then((response) => {
-      // Do a _post_custom_action_result_fields() from scripting.
-      const postResultFieldsEvent = {
-        name: 'create.output.post',
-        key: '<%= KEY %>',
-        response,
-      };
-      return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
-    });
+  return responsePromise.then(response => {
+    response.throwForStatus();
+
+    // Do a _post_custom_action_result_fields() from scripting.
+    const postResultFieldsEvent = {
+      name: 'create.output.post',
+      key: '<%= KEY %>',
+      response
+    };
+    return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
+  });
 };
 <% } else if (hasCustomOutputFields) { %>
 const getOutputFields = (z, bundle) => {
@@ -309,8 +333,10 @@ const getOutputFields = (z, bundle) => {
   const responsePromise = z.request({
     url: url
   });
-  return responsePromise
-    .then((response) => z.JSON.parse(response.content));
+  return responsePromise.then(response => {
+    response.throwForStatus();
+    return z.JSON.parse(response.content);
+  });
 };
 <% } %>
 module.exports = {

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -22,20 +22,22 @@ const getList = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preSearchEvent, z, bundle)
-    .then((preSearchResult) => z.request(preSearchResult))
+    .then(preSearchResult => z.request(preSearchResult))
 <% if (resourceFullScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // Do a _read_resource() from scripting.
       const fullResourceEvent = {
         name: 'search.resource',
         key: '<%= KEY %>',
-        results,
+        results
       };
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -44,7 +46,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting && resourcePostScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -52,23 +56,25 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -77,7 +83,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -85,13 +93,15 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -102,7 +112,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePostScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -115,17 +127,19 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, results[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -134,7 +148,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -145,7 +161,9 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, results[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -180,8 +198,10 @@ const getList = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preSearchEvent, z, bundle)
-    .then((preSearchResult) => z.request(preSearchResult))
-    .then((response) => {
+    .then(preSearchResult => z.request(preSearchResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_search() from scripting.
       const postSearchEvent = {
         name: 'search.post',
@@ -191,19 +211,19 @@ const getList = (z, bundle) => {
       return legacyScriptingRunner.runEvent(postSearchEvent, z, bundle);
     })
 <% if (resourceFullScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       const results = postSearchResult;
 
       // Do a _read_resource() from scripting.
       const fullResourceEvent = {
         name: 'search.resource',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -212,7 +232,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting && resourcePostScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -220,23 +240,25 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -245,7 +267,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -253,13 +275,15 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -270,7 +294,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePostScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -279,17 +303,19 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -298,18 +324,20 @@ const getList = (z, bundle) => {
       }
     });
 <% } else { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       if (!postSearchResult || postSearchResult.length === 0) {
         return {
-          content: '[]',
+          content: '[]'
         };
       }
 
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, postSearchResult[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -342,7 +370,9 @@ const getList = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_search() from scripting.
       const postSearchEvent = {
         name: 'search.post',
@@ -352,19 +382,19 @@ const getList = (z, bundle) => {
       return legacyScriptingRunner.runEvent(postSearchEvent, z, bundle);
     })
 <% if (resourceFullScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       const results = postSearchResult;
 
       // Do a _read_resource() from scripting.
       const fullResourceEvent = {
         name: 'search.resource',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -373,7 +403,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting && resourcePostScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -381,23 +411,25 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -406,7 +438,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -414,13 +446,15 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -431,7 +465,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePostScripting) { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = postSearchResult;
 
@@ -440,17 +474,19 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0, ));
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -459,18 +495,20 @@ const getList = (z, bundle) => {
       }
     });
 <% } else { %>
-    .then((postSearchResult) => {
+    .then(postSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       if (!postSearchResult || postSearchResult.length === 0) {
         return {
-          content: '[]',
+          content: '[]'
         };
       }
 
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, postSearchResult[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -502,23 +540,23 @@ const getList = (z, bundle) => {
   // Do a _search() from scripting.
   const fullSearchEvent = {
     name: 'search.search',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(fullSearchEvent, z, bundle)
 <% if (resourceFullScripting) { %>
-    .then((fullSearchResult) => {
+    .then(fullSearchResult => {
       const results = fullSearchResult;
 
       // Do a _read_resource() from scripting.
       const fullResourceEvent = {
         name: 'search.resource',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -527,7 +565,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting && resourcePostScripting) { %>
-    .then((fullSearchResult) => {
+    .then(fullSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = fullSearchResult;
 
@@ -535,23 +573,25 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -560,7 +600,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting) { %>
-    .then((fullSearchResult) => {
+    .then(fullSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = fullSearchResult;
 
@@ -568,13 +608,15 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -585,7 +627,7 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePostScripting) { %>
-    .then((fullSearchResult) => {
+    .then(fullSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       const results = fullSearchResult;
 
@@ -594,17 +636,19 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -613,18 +657,20 @@ const getList = (z, bundle) => {
       }
     });
 <% } else { %>
-    .then((fullSearchResult) => {
+    .then(fullSearchResult => {
       // Mimick the "fetch resource" that happened in WB
       if (!fullSearchResult || fullSearchResult.length === 0) {
         return {
-          content: '[]',
+          content: '[]'
         };
       }
 
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, fullSearchResult[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -659,19 +705,21 @@ const getList = (z, bundle) => {
   });
   return responsePromise
 <% if (resourceFullScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // Do a _read_resource() from scripting.
       const fullResourceEvent = {
         name: 'search.resource',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(bundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -680,7 +728,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting && resourcePostScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -688,23 +738,25 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -713,7 +765,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePreScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -721,13 +775,15 @@ const getList = (z, bundle) => {
       const preResourceEvent = {
         name: 'search.resource.pre',
         key: '<%= KEY %>',
-        results,
+        results
       };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
       return legacyScriptingRunner.runEvent(preResourceEvent, z, resourceBundle);
     })
-    .then((preResourceResult) => z.request(preResourceResult))
-    .then((response) => {
+    .then(preResourceResult => z.request(preResourceResult))
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -738,7 +794,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else if (resourcePostScripting) { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -751,17 +809,19 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, results[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_read_resource() from scripting.
       const postResourceEvent = {
         name: 'search.resource.post',
         key: '<%= KEY %>',
         response,
-        results: resourceBundle.results,
+        results: resourceBundle.results
       };
       return legacyScriptingRunner.runEvent(postResourceEvent, z, resourceBundle);
     })
-    .then((results) => {
+    .then(results => {
       // WB would return a single record, but in CLI we expect an array
       if (_.isArray(results)) {
         return results;
@@ -770,7 +830,9 @@ const getList = (z, bundle) => {
       }
     });
 <% } else { %>
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Mimick the "fetch resource" that happened in WB
       const results = z.JSON.parse(response.content);
 
@@ -781,7 +843,9 @@ const getList = (z, bundle) => {
       const finalUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, results[0]);
       return z.request({ url: finalUrl });
     })
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       const results = z.JSON.parse(response.content);
 
       // WB would return a single record, but in CLI we expect an array
@@ -824,8 +888,11 @@ const getInputFields = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
-    .then((preFieldsResult) => z.request(preFieldsResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preFieldsResult => z.request(preFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } else if (inputFieldPreScripting && inputFieldPostScripting) { %>
 const getInputFields = (z, bundle) => {
@@ -841,13 +908,15 @@ const getInputFields = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preFieldsEvent, z, bundle)
-    .then((preFieldsResult) => z.request(preFieldsResult))
-    .then((response) => {
+    .then(preFieldsResult => z.request(preFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_search_fields() from scripting.
       const postFieldsEvent = {
         name: 'search.input.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
     });
@@ -864,12 +933,14 @@ const getInputFields = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_search_fields() from scripting.
       const postFieldsEvent = {
         name: 'search.input.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postFieldsEvent, z, bundle);
     });
@@ -881,7 +952,10 @@ const getInputFields = (z, bundle) => {
 
   const responsePromise = z.request({ url });
   return responsePromise
-    .then((response) => z.JSON.parse(response.content));
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% }
 
@@ -896,7 +970,7 @@ const getOutputFields = (z, bundle) => {
   // Do a _custom_search_result_fields() from scripting.
   const fullResultFieldsEvent = {
     name: 'search.output',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
 };
@@ -911,11 +985,14 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'search.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } else if (outputFieldPreScripting && outputFieldPostScripting) { %>
 const getOutputFields = (z, bundle) => {
@@ -928,16 +1005,18 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'search.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => {
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_search_result_fields() from scripting.
       const postResultFieldsEvent = {
         name: 'search.output.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
     });
@@ -954,12 +1033,14 @@ const getOutputFields = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_search_result_fields() from scripting.
       const postResultFieldsEvent = {
         name: 'search.output.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
     });
@@ -971,7 +1052,10 @@ const getOutputFields = (z, bundle) => {
 
   const responsePromise = z.request({ url });
   return responsePromise
-    .then((response) => z.JSON.parse(response.content));
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } %>
 module.exports = {

--- a/scaffold/convert/trigger.template.js
+++ b/scaffold/convert/trigger.template.js
@@ -16,8 +16,11 @@ const getList = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(prePollEvent, z, bundle)
-    .then((prePollResult) => z.request(prePollResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(prePollResult => z.request(prePollResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <%
 }
@@ -37,8 +40,10 @@ const getList = (z, bundle) => {
     key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(prePollEvent, z, bundle)
-    .then((prePollResult) => z.request(prePollResult))
-    .then((response) => {
+    .then(prePollResult => z.request(prePollResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_poll() from scripting.
       const postPollEvent = {
         name: 'trigger.post',
@@ -64,7 +69,9 @@ const getList = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_poll() from scripting.
       const postPollEvent = {
         name: 'trigger.post',
@@ -89,7 +96,7 @@ const getList = (z, bundle) => {
   // Do a _poll() from scripting.
   const fullPollEvent = {
     name: 'trigger.poll',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(fullPollEvent, z, bundle);
 };
@@ -104,7 +111,10 @@ const getList = (z, bundle) => {
 
   const responsePromise = z.request({ url });
   return responsePromise
-    .then(response => z.JSON.parse(response.content));
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% }
 
@@ -119,11 +129,14 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'trigger.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => z.JSON.parse(response.content));
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } else if (outputFieldPreScripting && outputFieldPostScripting) { %>
 const getOutputFields = (z, bundle) => {
@@ -136,16 +149,18 @@ const getOutputFields = (z, bundle) => {
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
     name: 'trigger.output.pre',
-    key: '<%= KEY %>',
+    key: '<%= KEY %>'
   };
   return legacyScriptingRunner.runEvent(preResultFieldsEvent, z, bundle)
-    .then((preResultFieldsResult) => z.request(preResultFieldsResult))
-    .then((response) => {
+    .then(preResultFieldsResult => z.request(preResultFieldsResult))
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_trigger_fields() from scripting.
       const postResultFieldsEvent = {
         name: 'trigger.output.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
     });
@@ -162,12 +177,14 @@ const getOutputFields = (z, bundle) => {
     url: bundle._legacyUrl
   });
   return responsePromise
-    .then((response) => {
+    .then(response => {
+      response.throwForStatus();
+
       // Do a _post_custom_trigger_fields() from scripting.
       const postResultFieldsEvent = {
         name: 'trigger.output.post',
         key: '<%= KEY %>',
-        response,
+        response
       };
       return legacyScriptingRunner.runEvent(postResultFieldsEvent, z, bundle);
     });
@@ -181,7 +198,10 @@ const getOutputFields = (z, bundle) => {
     url: url
   });
   return responsePromise
-    .then((response) => z.JSON.parse(response.content));
+    .then(response => {
+      response.throwForStatus();
+      return z.JSON.parse(response.content);
+    });
 };
 <% } %>
 module.exports = {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -795,12 +795,21 @@ ${lines.join(',\n')}
 const renderDefaultInputData = definition => {
   const lines = [];
   _.each(definition.fields, (field, key) => {
-    if (field.default) {
-      const defaultValue = escapeSpecialChars(field.default);
-      lines.push(`'${key}': '${defaultValue}'`);
+    if (field.default || field.required) {
+      const defaultValue = field.default
+        ? quote(escapeSpecialChars(field.default))
+        : null;
+      lines.push(`'${key}': ${defaultValue}`);
     }
   });
-  return '{' + lines.join(',\n') + '}';
+
+  if (lines.length === 0) {
+    return '{}';
+  }
+  return `{
+    // TODO: Pulled from input fields' default values. Edit if necessary.
+    ${lines.join(',\n')}
+  }`;
 };
 
 const renderStepTest = (type, definition, key, legacyApp) => {


### PR DESCRIPTION
Currently, we add an input field to `inputData` in the generated test code [only if the field has a default value](https://github.com/zapier/zapier-platform-cli/pull/246/files#diff-1fac4925eaa46d1c8654ddd81c778787L798). What we want to do instead is to [include all the required fields](https://github.com/zapier/zapier-platform-cli/pull/246/files#diff-1fac4925eaa46d1c8654ddd81c778787R798) as well.

On the way, I also added `response.throwForStatus()` wherever fits to fix the issue where we get a false positive passing test even when we get a 4xx error response.