### PR TITLE
Remove 'debug' option from listLog opts

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -228,9 +228,7 @@ const listInvitees = () => {
 };
 
 const listLogs = opts => {
-  const cleaned = Object.assign({}, opts); // duplicate the original opts
-  delete cleaned.debug; // deletes debug flag if it exists
-  return listEndpoint(`logs?${qs.stringify(cleaned)}`, 'logs');
+  return listEndpoint(`logs?${qs.stringify(_.omit(opts, 'debug'))}`, 'logs');
 };
 
 const listEnv = version => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -228,7 +228,9 @@ const listInvitees = () => {
 };
 
 const listLogs = opts => {
-  return listEndpoint(`logs?${qs.stringify(opts)}`, 'logs');
+  const cleaned = Object.assign({}, opts); // duplicate the original opts
+  delete cleaned.debug; // deletes debug flag if it exists
+  return listEndpoint(`logs?${qs.stringify(cleaned)}`, 'logs');
 };
 
 const listEnv = version => {


### PR DESCRIPTION
Requests to /api/platform/cli/apps/{id}/logs?debug=true result in an error complaining about the 'debug' parameter. This commit will remove any 'debug' opt before sending the request to the logs api.

I'm not a JavaScript expert, so I went to the internet for help regarding cloning objects and removing properties from objects. I hope I did this the way others would (I didn't want to delete the 'debug' opt from the original object; I just wanted to remove it before sending the api request).