### PR TITLE
zapier convert: Add support for auth mapping templating

### DIFF
--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -3,16 +3,14 @@ const { replaceVars } = require('./utils');
 <% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <%
-  Object.keys(mapping).forEach((mapperKey) => {
-    fields.forEach((field) => {
-      if (mapping[mapperKey].indexOf(`{{${field}}}`) !== -1) {
-        if (query) { %>
-  request.params['<%= mapperKey %>'] = bundle.authData['<%= field %>'];
-<% } else { %>
-  request.headers['<%= mapperKey %>'] = bundle.authData['<%= field %>'];
-<%      }
-      }
-    });
+  Object.keys(mapping).forEach(key => {
+    let value = mapping[key];
+    value = value.replace(/\{\{(\w+)\}\}/g, "${bundle.authData['$1']}");
+    if (query) { %>
+      request.params['<%= key %>'] = `<%= value %>`;
+<%  } else { %>
+      request.headers['<%= key %>'] = `<%= value %>`;
+<%  }
   });
 %>
   return request;

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -213,12 +213,13 @@ describe('convert render functions', () => {
       const wbDef = definitions.apiHeader;
 
       return convert.getHeader(wbDef).then(string => {
-        string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  request.headers['Authorization'] = bundle.authData['api_key'];
-
-  return request;
-};
-`);
+        string.should.eql(
+          'const maybeIncludeAuth = (request, z, bundle) => {\n' +
+            "  request.headers['Authorization'] = `AccessKey ${bundle.authData['api_key']}`;\n" +
+            '\n' +
+            '  return request;\n' +
+            '};\n'
+        );
       });
     });
 
@@ -245,12 +246,13 @@ describe('convert render functions', () => {
       const wbDef = definitions.apiQuery;
 
       return convert.getHeader(wbDef).then(string => {
-        string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  request.params['api_key'] = bundle.authData['api_key'];
-
-  return request;
-};
-`);
+        string.should.eql(
+          'const maybeIncludeAuth = (request, z, bundle) => {\n' +
+            "  request.params['api_key'] = `${bundle.authData['api_key']}`;\n" +
+            '\n' +
+            '  return request;\n' +
+            '};\n'
+        );
       });
     });
 

--- a/src/tests/utils/definitions/api-header.json
+++ b/src/tests/utils/definitions/api-header.json
@@ -64,7 +64,7 @@
     "auth_data": {},
     "auth_label": "{{user}}",
     "auth_mapping": {
-      "Authorization": "{{api_key}}"
+      "Authorization": "AccessKey {{api_key}}"
     },
     "auth_type": "API Key (Headers)",
     "auth_urls": {},


### PR DESCRIPTION
Fixes PDE-64.

Try `zapier convert` a WB app with the following auth mapping:

![](https://cdn.zapier.com/storage/photos/9b5f3c3fc7602e2624e31b9900632370.png)

`zapier convert` currently generates the following auth middleware in `index.js`:

```js
const maybeIncludeAuth = (request, z, bundle) => {
  request.headers['Authorization'] = bundle.authData['AccessKey'];

  return request;
};
```

which doesn't reflect the actual mapping in the WB app. This PR fixes the issue so that it generates the correct code:

```js
const maybeIncludeAuth = (request, z, bundle) => {
  request.headers['Authorization'] = `AccessKey ${bundle.authData['AccessKey']}`;

  return request;
};
```