### PR TITLE
PDE-84: Exclude certain files from 'build --disable-dependency-detection'

### DIFF
--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -91,13 +91,20 @@ const requiredFiles = (cwd, entryPoints) => {
 };
 
 const listFiles = dir => {
+  const isBlacklisted = file_path => {
+    return ['.git', '.env', 'build'].find(excluded => {
+      return file_path.search(excluded) === 0;
+    });
+  };
+
   return new Promise((resolve, reject) => {
     const paths = [];
     const cwd = dir + path.sep;
     klaw(dir)
       .on('data', item => {
-        if (!item.stats.isDirectory()) {
-          paths.push(stripPath(cwd, item.path));
+        const stripped_path = stripPath(cwd, item.path);
+        if (!item.stats.isDirectory() && !isBlacklisted(stripped_path)) {
+          paths.push(stripped_path);
         }
       })
       .on('error', reject)


### PR DESCRIPTION
## Description
`zapier build --disable-dependency-detection` will exclude certain file paths that aren't necessary

## Type of Changes
<!--- Put an `✓` for the applicable box: -->
|   | Type |
| ------------- | ------------- |
|  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :link: Update dependencies |
|   | :scroll: Docs |


## Related Issue
[PDE-84](https://zapierorg.atlassian.net/browse/PDE-84)

## Testing Instructions
* Run `zapier build --disable-dependency-detection` and see that the excluded files are excluded

## TODOs
<!--- For PRs that are in-progress: -->
* [x] Add tests
* [x] All tests passing
