### PR TITLE
[MAJOR] json format only outputs valid json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,11 +1600,10 @@
       }
     },
     "cli-spinners": {
-      "version": "0.1.2",
+      "version": "1.1.0",
       "resolved":
-        "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-      "dev": true
+        "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
     },
     "cli-table2": {
       "version": "0.2.0",
@@ -1648,6 +1647,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
     "co": {
       "version": "4.6.0",
@@ -2151,6 +2155,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.3"
+      }
     },
     "define-property": {
       "version": "0.2.5",
@@ -5062,6 +5074,23 @@
             "supports-color": "2.0.0"
           }
         },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved":
+            "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "cli-spinners": {
+          "version": "0.1.2",
+          "resolved":
+            "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+          "dev": true
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -5080,6 +5109,35 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "ora": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-spinners": "0.1.2",
+            "object-assign": "4.1.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved":
+            "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         }
       }
@@ -5450,7 +5508,6 @@
         "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity":
         "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.1"
       }
@@ -6030,55 +6087,32 @@
       }
     },
     "ora": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-2.0.0.tgz",
+      "integrity":
+        "sha512-g+IR0nMUXq1k4nE3gkENbN4wkF0XsVZFyxznTF6CdmwQ9qeTGONGpSR9LM5//1l0TVvJoJF3MkMtJp6slUsWFg==",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "2.3.1",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "2.2.0",
+        "strip-ansi": "4.0.0",
+        "wcwidth": "1.0.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
+        "ansi-regex": {
+          "version": "3.0.0",
           "resolved":
-            "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
+            "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
+        "strip-ansi": {
+          "version": "4.0.0",
           "resolved":
-            "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
+            "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -7711,6 +7745,14 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "1.0.3"
+      }
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "minimatch": "3.0.3",
     "node-fetch": "1.7.1",
     "normalize-path": "2.0.1",
-    "ora": "^2.0.0",
+    "ora": "2.1.0",
     "prettier": "1.9.1",
     "read": "1.0.7",
     "readable-stream": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "minimatch": "3.0.3",
     "node-fetch": "1.7.1",
     "normalize-path": "2.0.1",
+    "ora": "^2.0.0",
     "prettier": "1.9.1",
     "read": "1.0.7",
     "readable-stream": "2.2.2",

--- a/src/commands/_access.js
+++ b/src/commands/_access.js
@@ -23,7 +23,7 @@ const makeAccess = (command, recordType) => {
                 app.title
               }".\n`
             );
-            utils.printStarting(`Removing ${email}`);
+            utils.startSpinner(`Removing ${email}`);
             return utils.callAPI(url, { method: 'DELETE' });
           } else {
             context.line(
@@ -31,12 +31,12 @@ const makeAccess = (command, recordType) => {
                 app.title
               }${msgExtra}".\n`
             );
-            utils.printStarting(`Adding ${email}`);
+            utils.startSpinner(`Adding ${email}`);
             return utils.callAPI(url, { method: 'POST' });
           }
         })
         .then(() => {
-          utils.printDone();
+          utils.endSpinner();
           context.line(
             `\n${_.capitalize(
               recordTypePlural

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -22,7 +22,7 @@ const convert = (context, appid, location) => {
       constants.BASE_ENDPOINT
     }/api/developer/v1/apps/${appid}/dump`;
 
-    utils.printStarting('Downloading app from Zapier');
+    utils.startSpinner('Downloading app from Zapier');
     return utils
       .callAPI(null, { url })
       .then(legacyApp => {
@@ -31,7 +31,7 @@ const convert = (context, appid, location) => {
         return legacyApp;
       })
       .then(legacyApp => {
-        utils.printDone();
+        utils.endSpinner();
         return legacyApp;
       })
       .then(legacyApp => utils.convertApp(legacyApp, tempAppDir));

--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -4,7 +4,7 @@ const deleteApp = (context, app) => {
   context.line(
     `Preparing to delete all versions of your app "${app.title}".\n`
   );
-  utils.printStarting('Deleting app');
+  utils.startSpinner('Deleting app');
   return utils.callAPI(`/apps/${app.id}`, {
     method: 'DELETE'
   });
@@ -14,7 +14,7 @@ const deleteVersion = (context, app, version) => {
   context.line(
     `Preparing to delete version ${version} of your app "${app.title}".\n`
   );
-  utils.printStarting(`Deleting version ${version}`);
+  utils.startSpinner(`Deleting version ${version}`);
   return utils.callAPI(`/apps/${app.id}/versions/${version}`, {
     method: 'DELETE'
   });
@@ -36,7 +36,7 @@ const _delete = (context, appOrVersion, version) => {
           : deleteApp(context, app)
     )
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line('  Deletion successful!\n');
     });
 };

--- a/src/commands/deprecate.js
+++ b/src/commands/deprecate.js
@@ -14,7 +14,7 @@ const deprecate = (context, version, deprecationDate) => {
         `Preparing to deprecate version ${version} your app "${app.title}".\n`
       );
       const url = '/apps/' + app.id + '/versions/' + version + '/deprecate';
-      utils.printStarting(`Deprecating ${version}`);
+      utils.startSpinner(`Deprecating ${version}`);
       return utils.callAPI(url, {
         method: 'PUT',
         body: {
@@ -23,7 +23,7 @@ const deprecate = (context, version, deprecationDate) => {
       });
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line('  Deprecation successful!\n');
       context.line(
         `We'll let users know that this version is no longer recommended and will cease to work on ${deprecationDate}.`

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -22,7 +22,7 @@ const env = (context, version, key, value) => {
         const startMsg = isRemove
           ? `Deleting ${key}`
           : `Setting ${key} to "${value}"`;
-        utils.printStarting(startMsg);
+        utils.startSpinner(startMsg);
 
         const method = isRemove ? 'DELETE' : 'PUT';
         return utils.callAPI(url, {
@@ -31,7 +31,7 @@ const env = (context, version, key, value) => {
         });
       })
       .then(() => {
-        utils.printDone();
+        utils.endSpinner();
         context.line();
         context.line(
           `Environment updated! Try viewing it with \`zapier env ${version}\`.`

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -13,13 +13,13 @@ const init = (context, location) => {
 
   const template = global.argOpts.template || 'minimal';
   const createApp = tempAppDir => {
-    utils.printStarting(
+    utils.startSpinner(
       `Downloading zapier/zapier-platform-example-app-${template} starter app`
     );
     return exampleApps
       .downloadAndUnzipTo(template, tempAppDir)
       .then(() => exampleApps.removeReadme(tempAppDir))
-      .then(() => utils.printDone());
+      .then(() => utils.endSpinner());
   };
 
   return utils.initApp(context, location, createApp).then(() => {

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -54,17 +54,17 @@ const link = context => {
       if (hasCancelled(answer)) {
         throw new Error('Cancelled link operation.');
       } else {
-        utils.printStarting(`Selecting existing app "${appMap[answer].title}"`);
+        utils.startSpinner(`Selecting existing app "${appMap[answer].title}"`);
         return appMap[answer];
       }
     })
     .then(app => {
-      utils.printDone();
-      utils.printStarting(`Setting up \`${constants.CURRENT_APP_FILE}\` file`);
+      utils.endSpinner();
+      utils.startSpinner(`Setting up \`${constants.CURRENT_APP_FILE}\` file`);
       return utils.writeLinkedAppConfig(app);
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line(
         '\nFinished! You can `zapier push` now to build & upload a version!'
       );

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -9,7 +9,7 @@ const logout = context => {
 
   return Promise.resolve()
     .then(() => {
-      utils.printStarting('Deactivating personal deploy keys');
+      utils.startSpinner('Deactivating personal deploy keys');
       return utils
         .callAPI('/keys', {
           method: 'DELETE'
@@ -18,12 +18,12 @@ const logout = context => {
         .catch(() => true);
     })
     .then(() => {
-      utils.printDone();
-      utils.printStarting(`Destroying \`${constants.AUTH_LOCATION_RAW}\``);
+      utils.endSpinner();
+      utils.startSpinner(`Destroying \`${constants.AUTH_LOCATION_RAW}\``);
       return utils.deleteFile(constants.AUTH_LOCATION);
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line();
       context.line(
         'All personal deploy keys deactivated - now try `zapier login` to login again.'

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -4,9 +4,9 @@ const colors = require('colors/safe');
 const logs = context => {
   context.line('The logs of your app listed below.\n');
 
-  utils.startSpinner();
+  utils.startSpinner('Loading your logs');
   return utils.listLogs(global.argOpts).then(data => {
-    utils.endSpinner('');
+    utils.endSpinner();
 
     let columns;
     const type = global.argOpts.type || logs.argOptsSpec.type.default;

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -30,7 +30,7 @@ const migrate = (context, fromVersion, toVersion, optionalPercent = '100%') => {
             app.title
           }" from ${fromVersion} to ${toVersion}.\n`
         );
-        utils.printStarting(
+        utils.startSpinner(
           `Starting migration from ${fromVersion} to ${toVersion} for ${user}`
         );
       } else {
@@ -39,7 +39,7 @@ const migrate = (context, fromVersion, toVersion, optionalPercent = '100%') => {
             app.title
           }" from ${fromVersion} to ${toVersion}.\n`
         );
-        utils.printStarting(
+        utils.startSpinner(
           `Starting migration from ${fromVersion} to ${toVersion} for ${optionalPercent}%`
         );
       }
@@ -53,7 +53,7 @@ const migrate = (context, fromVersion, toVersion, optionalPercent = '100%') => {
       );
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line(
         '\nMigration successfully queued, please check `zapier history` to track the status. Migrations usually take between 5-10 minutes.'
       );

--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -76,14 +76,10 @@ const promote = (context, version) => {
       }
 
       utils.startSpinner(`Promoting ${version}`);
-      return utils.callAPI(
-        url,
-        {
-          method: 'PUT',
-          body
-        },
-        false
-      );
+      return utils.callAPI(url, {
+        method: 'PUT',
+        body
+      });
     })
     .then(() => {
       utils.endSpinner();

--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -63,6 +63,7 @@ const promote = (context, version) => {
       return utils.promiseDoWhile(action, stop);
     })
     .then(answer => {
+      context.line();
       if (hasCancelled(answer)) {
         throw new Error('Cancelled promote.');
       }
@@ -74,7 +75,7 @@ const promote = (context, version) => {
         body.changelog = changelog;
       }
 
-      utils.printStarting(`Promoting ${version}`);
+      utils.startSpinner(`Promoting ${version}`);
       return utils.callAPI(
         url,
         {
@@ -85,7 +86,7 @@ const promote = (context, version) => {
       );
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       context.line('  Promotion successful!\n');
       context.line(
         'Optionally try the `zapier migrate 1.0.0 1.0.1 [10%]` command to move users to this version.'
@@ -98,7 +99,7 @@ const promote = (context, version) => {
           'You cannot promote until we have approved your app.'
         ) !== -1
       ) {
-        utils.printDone();
+        utils.endSpinner();
         context.line(
           '\nGood news! Your app passes validation and has the required number of testers and active Zaps.\n'
         );

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -10,8 +10,7 @@ const register = (context, title, { printWhenDone = true } = {}) => {
   return utils
     .checkCredentials()
     .then(() => {
-      utils.printDone();
-      utils.printStarting(`Confirming registation of app "${title}"`);
+      utils.startSpinner(`Confirming registation of app "${title}"`);
       return utils.callAPI('/apps', {
         method: 'POST',
         body: {
@@ -20,8 +19,8 @@ const register = (context, title, { printWhenDone = true } = {}) => {
       });
     })
     .then(app => {
-      utils.printDone();
-      utils.printStarting(
+      utils.endSpinner();
+      utils.startSpinner(
         `Linking app to current directory with \`${
           constants.CURRENT_APP_FILE
         }\``
@@ -29,7 +28,7 @@ const register = (context, title, { printWhenDone = true } = {}) => {
       return utils.writeLinkedAppConfig(app, appDir);
     })
     .then(() => {
-      utils.printDone();
+      utils.endSpinner();
       if (printWhenDone) {
         context.line(
           '\nFinished! Now that your app is registered with Zapier, you can `zapier push` a version!'

--- a/src/commands/scaffold.js
+++ b/src/commands/scaffold.js
@@ -13,12 +13,12 @@ const writeTemplateFile = (templatePath, templateContext, dest) => {
       _.template(template, { interpolate: /<%=([\s\S]+?)%>/g })(templateContext)
     )
     .then(rendered => {
-      utils.printStarting(`Writing new ${dest}.js`);
+      utils.startSpinner(`Writing new ${dest}.js`);
       return utils
         .ensureDir(path.dirname(destPath))
         .then(() => utils.writeFile(destPath, rendered));
     })
-    .then(() => utils.printDone());
+    .then(() => utils.endSpinner());
 };
 
 const scaffold = (context, type, name) => {
@@ -83,7 +83,7 @@ const scaffold = (context, type, name) => {
     .then(() => utils.readFile(entryFile))
     .then(entryBuf => entryBuf.toString())
     .then(entryJs => {
-      utils.printStarting(`Rewriting your ${entry}`);
+      utils.startSpinner(`Rewriting your ${entry}`);
       let lines = entryJs.split('\n');
 
       // this is very dumb and will definitely break, it inserts lines of code
@@ -101,7 +101,7 @@ const scaffold = (context, type, name) => {
         _.endsWith(line, injectAfter)
       );
       if (linesDefIndex === -1) {
-        utils.printDone(false);
+        utils.endSpinner(false);
         context.line();
         context.line(
           colors.bold(`Oops, we could not reliably rewrite your ${entry}.`) +
@@ -116,7 +116,7 @@ const scaffold = (context, type, name) => {
         lines.splice(linesDefIndex + 1, 0, '    ' + injectorLine);
         return utils
           .writeFile(entryFile, lines.join('\n'))
-          .then(() => utils.printDone());
+          .then(() => utils.endSpinner());
       }
     })
     .then(() =>

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -76,13 +76,13 @@ const watch = context => {
     if (fileName.startsWith('.git')) {
       return;
     }
-    utils.printStarting(`Reloading for ${fileName}`);
+    utils.startSpinner(`Reloading for ${fileName}`);
     resetHandler()
       .then(reloadDefinition)
       .then(pingZapierForTunnel)
-      .then(() => utils.printDone())
+      .then(() => utils.endSpinner())
       .catch(err => {
-        utils.printDone(false);
+        utils.endSpinner(false);
         context.line(err);
         // don't print err.stack until we use require('syntax-error') or similar
       });
@@ -94,16 +94,16 @@ const watch = context => {
     .checkCredentials()
     .then(() => utils.getLinkedApp())
     .then(app => {
-      utils.printStarting('Starting local server on port ' + options.port);
+      utils.startSpinner('Starting local server on port ' + options.port);
       return Promise.all([app, utils.localAppTunnelServer(options)]);
     })
     .then(([app, server]) => {
-      utils.printDone();
-      utils.printStarting('Starting local tunnel for port ' + options.port);
+      utils.endSpinner();
+      utils.startSpinner('Starting local tunnel for port ' + options.port);
       return Promise.all([app, server, utils.makeTunnelUrl(options.port)]);
     })
     .then(([app, server, _proxyUrl]) => {
-      utils.printDone();
+      utils.endSpinner();
 
       localAppId = app.id;
       localProxyUrl = _proxyUrl;

--- a/src/entry.js
+++ b/src/entry.js
@@ -10,12 +10,6 @@ const commands = require('./commands');
 const utils = require('./utils');
 
 module.exports = argv => {
-  process.on('exit', utils.clearSpinner);
-  process.on('SIGINT', () => {
-    utils.clearSpinner();
-    process.exit();
-  });
-
   if (!utils.isValidNodeVersion()) {
     console.error(
       colors.red(
@@ -91,7 +85,6 @@ module.exports = argv => {
   };
   const errors = utils.enforceArgSpec(spec, args, argOpts);
   if (errors.length) {
-    utils.clearSpinner();
     context.line();
     context.line(
       colors.red(
@@ -106,28 +99,24 @@ module.exports = argv => {
     process.exit(1);
   }
 
-  commandFunc
-    .apply(commands, [context].concat(args))
-    .then(() => {
-      utils.clearSpinner();
-    })
-    .catch(err => {
-      utils.printDone(false, err.message);
-      if (DEBUG || global.argOpts.debug) {
-        context.line();
-        context.line(err.stack);
-        context.line();
-        context.line(colors.red('Error!'));
-      } else {
-        context.line();
-        context.line();
-        context.line(colors.red('Error!') + ' ' + colors.red(err.message));
-        context.line(
-          colors.grey(
-            '(Use --debug flag and run this command again to get more details.)'
-          )
-        );
-      }
-      process.exit(1);
-    });
+  commandFunc.apply(commands, [context].concat(args)).catch(err => {
+    utils.endSpinner(false);
+
+    if (DEBUG || global.argOpts.debug) {
+      context.line();
+      context.line(err.stack);
+      context.line();
+      context.line(colors.red('Error!'));
+    } else {
+      context.line();
+      context.line();
+      context.line(colors.red('Error!') + ' ' + colors.red(err.message));
+      context.line(
+        colors.grey(
+          '(Use --debug flag and run this command again to get more details.)'
+        )
+      );
+    }
+    process.exit(1);
+  });
 };

--- a/src/entry.js
+++ b/src/entry.js
@@ -112,7 +112,7 @@ module.exports = argv => {
       utils.clearSpinner();
     })
     .catch(err => {
-      utils.clearSpinner();
+      utils.printDone(false, err.message);
       if (DEBUG || global.argOpts.debug) {
         context.line();
         context.line(err.stack);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -41,7 +41,7 @@ const readCredentials = (explodeIfMissing = true) => {
 };
 
 // Calls the underlying platform REST API with proper authentication.
-const callAPI = (route, options, displayError = true) => {
+const callAPI = (route, options) => {
   options = options || {};
   const url = options.url || constants.ENDPOINT + route;
 
@@ -95,8 +95,6 @@ const callAPI = (route, options, displayError = true) => {
         }
         console.log(`<< ${res.status}`);
         console.log(`<< ${(text || '').substring(0, 2500)}\n`);
-      } else if (hitError && displayError) {
-        endSpinner(false);
       }
 
       if (hitError) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -13,7 +13,7 @@ const semver = require('semver');
 
 const { writeFile, readFile } = require('./files');
 
-const { prettyJSONstringify, printStarting, printDone } = require('./display');
+const { prettyJSONstringify, startSpinner, endSpinner } = require('./display');
 
 const { localAppCommand } = require('./local');
 
@@ -96,7 +96,7 @@ const callAPI = (route, options, displayError = true) => {
         console.log(`<< ${res.status}`);
         console.log(`<< ${(text || '').substring(0, 2500)}\n`);
       } else if (hitError && displayError) {
-        printDone(false);
+        endSpinner(false);
       }
 
       if (hitError) {
@@ -257,7 +257,7 @@ const upload = (zipPath, appDir) => {
       const binaryZip = fs.readFileSync(fullZipPath);
       const buffer = Buffer.from(binaryZip).toString('base64');
 
-      printStarting(`Uploading version ${definition.version}`);
+      startSpinner(`Uploading version ${definition.version}`);
       return callAPI(`/apps/${app.id}/versions/${definition.version}`, {
         method: 'PUT',
         body: {
@@ -266,7 +266,7 @@ const upload = (zipPath, appDir) => {
       });
     })
     .then(appVersion => {
-      printDone();
+      endSpinner();
 
       if (semver.lt(appVersion.platform_version, appVersion.core_npm_version)) {
         console.log(

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -22,7 +22,7 @@ const {
   removeDir
 } = require('./files');
 
-const { prettyJSONstringify, printStarting, printDone } = require('./display');
+const { prettyJSONstringify, startSpinner, endSpinner } = require('./display');
 
 const {
   getLinkedAppConfig,
@@ -255,7 +255,7 @@ const build = (zipPath, wdir) => {
   return ensureDir(tmpDir)
     .then(() => ensureDir(constants.BUILD_DIR))
     .then(() => {
-      printStarting('Copying project to temp directory');
+      startSpinner('Copying project to temp directory');
 
       let filter;
       if (process.env.SKIP_NPM_INSTALL) {
@@ -270,13 +270,13 @@ const build = (zipPath, wdir) => {
       if (process.env.SKIP_NPM_INSTALL) {
         return {};
       }
-      printDone();
-      printStarting('Installing project dependencies');
+      endSpinner();
+      startSpinner('Installing project dependencies');
       return runCommand('npm', ['install', '--production'], { cwd: tmpDir });
     })
     .then(() => {
-      printDone();
-      printStarting('Applying entry point file');
+      endSpinner();
+      startSpinner('Applying entry point file');
       // TODO: should this routine for include exist elsewhere?
       return readFile(
         path.join(
@@ -291,8 +291,8 @@ const build = (zipPath, wdir) => {
       );
     })
     .then(() => {
-      printDone();
-      printStarting('Building app definition.json');
+      endSpinner();
+      startSpinner('Building app definition.json');
       return _appCommandZapierWrapper(tmpDir, { command: 'definition' });
     })
     .then(rawDefinition => {
@@ -316,8 +316,8 @@ const build = (zipPath, wdir) => {
         );
       }
 
-      printDone();
-      printStarting('Validating project');
+      endSpinner();
+      startSpinner('Validating project');
 
       return Promise.all([
         _appCommandZapierWrapper(tmpDir, { command: 'validate' }),
@@ -351,16 +351,16 @@ const build = (zipPath, wdir) => {
         );
       }
 
-      printDone();
-      printStarting('Zipping project and dependencies');
+      endSpinner();
+      startSpinner('Zipping project and dependencies');
       return makeZip(tmpDir, wdir + path.sep + zipPath);
     })
     .then(() => {
       // tries to do a reproducible build at least
       // https://blog.pivotal.io/labs/labs/barriers-deterministic-reproducible-zip-files
       // https://reproducible-builds.org/tools/ or strip-nondeterminism
-      printDone();
-      printStarting('Testing build');
+      endSpinner();
+      startSpinner('Testing build');
 
       if (isWindows()) {
         return {}; // TODO err, what should we do on windows?
@@ -372,12 +372,12 @@ const build = (zipPath, wdir) => {
       );
     })
     .then(() => {
-      printDone();
-      printStarting('Cleaning up temp directory');
+      endSpinner();
+      startSpinner('Cleaning up temp directory');
       return removeDir(tmpDir);
     })
     .then(() => {
-      printDone();
+      endSpinner();
       return zipPath;
     });
 };

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -4,8 +4,8 @@ const createContext = ({ command, args, argOpts } = {}) => {
     args,
     argOpts,
     line: _line => {
-      // throwing in extra text makes output invalid json
-      if (argOpts.format !== 'json') {
+      // json-like formats should only print json output, not text
+      if (!['json', 'raw'].includes(argOpts.format)) {
         console.log(_line || '');
       }
     }

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -3,7 +3,12 @@ const createContext = ({ command, args, argOpts } = {}) => {
     command,
     args,
     argOpts,
-    line: _line => console.log(_line || '')
+    line: _line => {
+      // throwing in extra text makes output invalid json
+      if (argOpts.format !== 'json') {
+        console.log(_line || '');
+      }
+    }
   };
 };
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -4,7 +4,7 @@ const prettier = require('prettier');
 const stripComments = require('strip-comments');
 const { camelCase, snakeCase } = require('./misc');
 const { copyFile, readFile, writeFile, ensureDir } = require('./files');
-const { printStarting, printDone } = require('./display');
+const { startSpinner, endSpinner } = require('./display');
 const { PACKAGE_VERSION } = require('../constants');
 
 const TEMPLATE_DIR = path.join(__dirname, '../../scaffold/convert');
@@ -101,8 +101,8 @@ const createFile = (content, fileName, dir) => {
   return ensureDir(path.dirname(destFile))
     .then(() => writeFile(destFile, content))
     .then(() => {
-      printStarting(`Writing ${fileName}`);
-      printDone();
+      startSpinner(`Writing ${fileName}`);
+      endSpinner();
     });
 };
 
@@ -1039,8 +1039,8 @@ const writeGitIgnore = newAppDir => {
   const srcPath = path.join(TEMPLATE_DIR, '/gitignore');
   const destPath = path.join(newAppDir, '/.gitignore');
   return copyFile(srcPath, destPath).then(() => {
-    printStarting('Writing .gitignore');
-    printDone();
+    startSpinner('Writing .gitignore');
+    endSpinner();
   });
 };
 

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -222,29 +222,24 @@ const printData = (
   }
 };
 
-const spin = ora();
+// single global instance of the spinner
+const spinner = ora();
 
-const clearSpinner = () => {
-  spin.clear();
+const startSpinner = msg => {
+  spinner.start(msg);
 };
 
-const startSpinner = () => {
-  spin.start();
-};
+const endSpinner = (success = true, message) => {
+  // only stop if it was started in the first place
+  // this is undocumented, but seems like it works; i filed an issue
+  if (!spinner.id) {
+    return;
+  }
 
-const endSpinner = () => {
-  spin.succeed();
-};
-
-const printStarting = msg => {
-  spin.start(msg);
-};
-
-const printDone = (success = true, message) => {
   if (success) {
-    spin.succeed(message);
+    spinner.succeed(message);
   } else {
-    spin.fail(message);
+    spinner.fail(message);
   }
 };
 
@@ -268,8 +263,6 @@ const getInput = (question, { secret = false } = {}) => {
 };
 
 module.exports = {
-  clearSpinner,
-  endSpinner,
   formatStyles,
   getInput,
   makeRowBasedTable,
@@ -277,7 +270,6 @@ module.exports = {
   markdownLog,
   prettyJSONstringify,
   printData,
-  printDone,
-  printStarting,
+  endSpinner,
   startSpinner
 };

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -219,7 +219,11 @@ const printData = (
     (global.argOpts || {}).format || (useRowBasedTable ? 'row' : DEFAULT_STYLE);
   const formatter = formatStyles[formatStyle] || formatStyles[DEFAULT_STYLE];
   if (rows && !rows.length) {
-    console.log(ifEmptyMessage);
+    if (['json', 'raw'].includes(formatStyle)) {
+      console.log([]);
+    } else {
+      console.log(ifEmptyMessage);
+    }
   } else {
     console.log(formatter(rows, columnDefs));
   }
@@ -234,8 +238,7 @@ const startSpinner = msg => {
 
 const endSpinner = (success = true, message) => {
   // only stop if it was started in the first place
-  // this is undocumented, but seems like it works; i filed an issue
-  if (!spinner.id) {
+  if (!spinner.isSpinning) {
     return;
   }
 

--- a/src/utils/init.js
+++ b/src/utils/init.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const tmp = require('tmp');
 
-const { printStarting, printDone, getInput } = require('./display');
+const { startSpinner, endSpinner, getInput } = require('./display');
 const { isEmptyDir, copyDir, removeDir, ensureDir } = require('./files');
 
 const confirmNonEmptyDir = location => {
@@ -30,12 +30,12 @@ const initApp = (context, location, createApp) => {
   const copyOpts = {
     clobber: false,
     onCopy: file => {
-      printStarting(`Copy ${file}`);
-      printDone();
+      startSpinner(`Copy ${file}`);
+      endSpinner();
     },
     onSkip: file => {
-      printStarting(`File ${file} already exists`);
-      printDone(true, 'skipped');
+      startSpinner(`File ${file} already exists (skipped)`);
+      endSpinner();
     }
   };
 


### PR DESCRIPTION
In order for command output to be piped into other commands (such as `jq`, a json formatter), it can't print extra helpful lines or other, non-json text.

The fix is twofold. The easier side is not printing "these are your apps:" and similar. that's a single check in the `context.line` function.

The more complex half is our custom spinner implementation, which prints out hidden characters when it starts and stops (not to mention, it's very complex), invalidating the output. Moved the spinner to an external lib that's well maintained (`ora`). initial results seem [awesome](https://cdn.zapier.com/storage/photos/e102adcf307a1b02d167601baf1aeda5.png) but there's still a lot of tire-kicking to do there. 

fixes #247 and [PDE-89](https://zapierorg.atlassian.net/browse/PDE-89)