### PR TITLE
zapier convert: Ensure samples are converted

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -359,6 +359,7 @@ module.exports = {
 <%= SAMPLE %><% if (hasCustomOutputFields) { %><% if (SAMPLE) { %>,<% } %>
       getOutputFields<% } %>
     ],
-    perform: makeRequest
+    perform: makeRequest,
+    sample: <%= SAMPLE %>
   }
 };

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -1078,6 +1078,7 @@ module.exports = {
 <%= SAMPLE %><% if (hasCustomOutputFields) { %><% if (SAMPLE) { %>,<% } %>
       getOutputFields<% } %>
     ],
-    perform: getList
+    perform: getList,
+    sample: <%= SAMPLE %>
   }
 };

--- a/scaffold/convert/trigger.template.js
+++ b/scaffold/convert/trigger.template.js
@@ -220,9 +220,10 @@ module.exports = {
 <%= FIELDS %>
     ],
     outputFields: [
-<%= SAMPLE %><% if (hasCustomOutputFields) { %><% if (SAMPLE) { %>,<% } %>
+<%= SAMPLE_FIELDS %><% if (hasCustomOutputFields) { %><% if (SAMPLE_FIELDS) { %>,<% } %>
       getOutputFields<% } %>
     ],
-    perform: getList
+    perform: getList,
+    sample: <%= SAMPLE %>
   }
 };

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -626,7 +626,7 @@ const getSessionKey = (z, bundle) => {
     });
   });
 
-  describe('render sample', () => {
+  describe('render sample fields', () => {
     it('should render sample output fields', () => {
       const wbFields = [
         { type: 'float', key: 'bounds__northeast__lat' },
@@ -642,7 +642,7 @@ const getSessionKey = (z, bundle) => {
         }
       ];
 
-      const string = '[' + convert.renderSample(wbFields) + ']';
+      const string = '[' + convert.renderSampleFields(wbFields) + ']';
       const cliFields = s2js(string);
       cliFields.should.eql([
         { type: 'number', key: 'bounds__northeast__lat' },

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -199,7 +199,7 @@ ${props.join(',\n')}
 ${padding}}`;
 };
 
-const renderSample = (fields, indent = 0) => {
+const renderSampleFields = (fields, indent = 0) => {
   const results = [];
   _.each(fields, field => {
     results.push(renderSampleField(field, indent));
@@ -662,7 +662,8 @@ const renderStep = (type, definition, key, legacyApp) => {
   const stepMeta = getStepMetaData(legacyApp, type, key);
 
   const fields = renderFields(definition.fields, 6);
-  const sample = renderSample(definition.sample_result_fields, 6);
+  const sampleFields = renderSampleFields(definition.sample_result_fields, 6);
+  const sample = JSON.stringify(definition.sample_result) || 'null';
 
   const url = definition.url
     ? definition.url
@@ -687,6 +688,7 @@ const renderStep = (type, definition, key, legacyApp) => {
     HIDDEN: hidden,
     IMPORTANT: important,
     FIELDS: fields,
+    SAMPLE_FIELDS: sampleFields,
     SAMPLE: sample,
     URL: url,
     scripting: stepMeta.hasScripting,
@@ -1074,7 +1076,7 @@ module.exports = {
   renderAuth,
   renderField,
   renderIndex,
-  renderSample,
+  renderSampleFields,
   renderScripting,
   renderStep,
   renderTemplate,


### PR DESCRIPTION
Addresses PDE-103. Since `sample` became required, it should be included in the generated CLI app. This PR improves `zapier convert` so that the generated trigger/create/search also has the samples from a WB app.

Must be merged **after** the backend PR zapier/zapier#16138.