### PR TITLE
zapier convert: Add support for static dropdown

### DIFF
--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -100,6 +100,26 @@ describe('convert render functions', () => {
       field.helpText.should.eql("That's ok");
     });
 
+    it('should convert a static dropdown', () => {
+      const wbKey = 'genre';
+      const wbDef = {
+        key: 'genre',
+        label: 'Genre',
+        type: 'Unicode',
+        required: true,
+        choices: 'drama,scifi|Sci-Fi,super-hero|Super Hero,thriller'
+      };
+
+      const string = convert.renderField(wbDef, wbKey);
+      const field = s2js(string);
+      field.choices.should.eql({
+        drama: 'Drama',
+        scifi: 'Sci-Fi',
+        'super-hero': 'Super Hero',
+        thriller: 'Thriller'
+      });
+    });
+
     it('should convert a dynamic dropdown', () => {
       const wbKey = 'test';
       const wbDef = {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -162,6 +162,19 @@ const renderField = (definition, key, indent = 0) => {
     );
   }
 
+  if (definition.choices) {
+    const choices = {};
+    _.each(definition.choices.split(','), choice => {
+      const parts = choice.split('|');
+      const choiceKey = parts[0].trim();
+      const choiceLabel =
+        parts.length > 1 ? parts[1].trim() : _.startCase(choiceKey);
+      choices[choiceKey] = choiceLabel;
+    });
+
+    props.push(renderProp('choices', JSON.stringify(choices)));
+  }
+
   props = props.map(s => ' '.repeat(indent + 2) + s);
   const padding = ' '.repeat(indent);
 


### PR DESCRIPTION
Addresses PDE-62. Adds support for static dropdown for `zapier convert` command.

Example:

```
zapier convert 49075 nytimes
```