### PR TITLE
zapier convert: Fix output fields for create and search

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -356,7 +356,7 @@ module.exports = {
       getInputFields<% } %>
     ],
     outputFields: [
-<%= SAMPLE_FILEDS %><% if (hasCustomOutputFields) { %><% if (SAMPLE_FIELDS) { %>,<% } %>
+<%= SAMPLE_FIELDS %><% if (hasCustomOutputFields) { %><% if (SAMPLE_FIELDS) { %>,<% } %>
       getOutputFields<% } %>
     ],
     perform: makeRequest,

--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -356,7 +356,7 @@ module.exports = {
       getInputFields<% } %>
     ],
     outputFields: [
-<%= SAMPLE %><% if (hasCustomOutputFields) { %><% if (SAMPLE) { %>,<% } %>
+<%= SAMPLE_FILEDS %><% if (hasCustomOutputFields) { %><% if (SAMPLE_FIELDS) { %>,<% } %>
       getOutputFields<% } %>
     ],
     perform: makeRequest,

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -1075,7 +1075,7 @@ module.exports = {
       getInputFields<% } %>
     ],
     outputFields: [
-<%= SAMPLE %><% if (hasCustomOutputFields) { %><% if (SAMPLE) { %>,<% } %>
+<%= SAMPLE_FIELDS %><% if (hasCustomOutputFields) { %><% if (SAMPLE_FIELDS) { %>,<% } %>
       getOutputFields<% } %>
     ],
     perform: getList,


### PR DESCRIPTION
#266 added `sample` to trigger/create/search templates and renamed `SAMPLE` to `SAMPLE_FIELDS` for trigger template. But I forgot to rename `SAMPLE` to `SAMPLE_FIELDS` as well for create and search templates. This PR fixes it.