### PR TITLE
zapier convert: Call beforeRequest middlewares explicitly for full scripting methods

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -1,5 +1,9 @@
 // "Create" stub created by 'zapier convert'. This is just a stub - you will need to edit!
 const { replaceVars } = require('../utils');
+<% if (fullScripting || inputFieldFullScripting || outputFieldFullScripting) { %>
+  const { runBeforeMiddlewares } = require('../utils');
+<% } %>
+
 <%
 // Template for just _pre_write()
 if (preScripting && !postScripting && !fullScripting) { %>
@@ -102,13 +106,19 @@ const makeRequest = (z, bundle) => {
 
   bundle._legacyUrl = '<%= URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _write() from scripting.
-  const fullWriteEvent = {
-    name: 'create.write',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullWriteEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _write() from scripting.
+      const fullWriteEvent = {
+        name: 'create.write',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullWriteEvent, z, bundle);
+    });
 };
 <%
 }
@@ -146,13 +156,19 @@ const getInputFields = (z, bundle) => {
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _custom_action_fields() from scripting.
-  const fullFieldsEvent = {
-    name: 'create.input',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _custom_action_fields() from scripting.
+      const fullFieldsEvent = {
+        name: 'create.input',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+    });
 };
 <% } else if (inputFieldPreScripting && !inputFieldPostScripting) { %>
 const getInputFields = (z, bundle) => {
@@ -247,13 +263,19 @@ const getOutputFields = (z, bundle) => {
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _custom_action_result_fields() from scripting.
-  const fullResultFieldsEvent = {
-    name: 'create.output',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _custom_action_result_fields() from scripting.
+      const fullResultFieldsEvent = {
+        name: 'create.output',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
+    });
 };
 <% } else if (outputFieldPreScripting && !outputFieldPostScripting) { %>
 const getOutputFields = (z, bundle) => {

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -42,6 +42,9 @@ if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 
 if (before && oauth) { %>const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
+    if (!request.headers) {
+      request.headers = {};
+    }
     request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
   }
   return request;

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -2,6 +2,11 @@
 const { replaceVars } = require('./utils');
 <% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
+  <% if (!query) { %>
+    if (!request.headers) {
+      request.headers = {};
+    }
+  <% } %>
 <%
   Object.keys(mapping).forEach(key => {
     let value = mapping[key];
@@ -30,10 +35,12 @@ const maybeIncludeAuth = (request, z, bundle) => {
 <% }
 
 if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
-<%
-  if (query) { %>
+<% if (query) { %>
   request.params['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;;
 <% } else { %>
+  if (!request.headers) {
+    request.headers = {};
+  }
   request.headers['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;
 <% } %>
   return request;

--- a/scaffold/convert/package.template.json
+++ b/scaffold/convert/package.template.json
@@ -4,7 +4,7 @@
   "description": "<%= DESCRIPTION %>",
   "main": "index.js",
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --recursive"
+    "test": "node node_modules/mocha/bin/mocha --recursive -t 10000"
   },
   "engines": {
     "node": ">=6.10.0",

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -1,6 +1,11 @@
 // Search stub created by 'zapier convert'. This is just a stub - you will need to edit!
 const _ = require('lodash');
 const { replaceVars } = require('../utils');
+
+<% if (fullScripting || resourceFullScripting || inputFieldFullScripting || outputFieldFullScripting) { %>
+  const { runBeforeMiddlewares } = require('../utils');
+<% } %>
+
 <%
 // Template for just _pre_search()
 if (preScripting && !postScripting && !fullScripting) { %>
@@ -29,13 +34,19 @@ const getList = (z, bundle) => {
 
       const results = z.JSON.parse(response.content);
 
-      // Do a _read_resource() from scripting.
-      const fullResourceEvent = {
-        name: 'search.resource',
-        key: '<%= KEY %>',
-        results
-      };
-      return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
+      resourceBundle.request = { url: resourceBundle._legacyUrl };
+      return runBeforeMiddlewares(resourceBundle.request, z, resourceBundle)
+        .then(request => {
+          // Do a _read_resource() from scripting.
+          const fullResourceEvent = {
+            name: 'search.resource',
+            key: '<%= KEY %>',
+            results
+          };
+          resourceBundle.request = request;
+          return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+        });
     })
     .then(results => {
       // WB would return a single record, but in CLI we expect an array
@@ -214,14 +225,19 @@ const getList = (z, bundle) => {
     .then(postSearchResult => {
       const results = postSearchResult;
 
-      // Do a _read_resource() from scripting.
-      const fullResourceEvent = {
-        name: 'search.resource',
-        key: '<%= KEY %>',
-        results
-      };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
-      return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+      resourceBundle.request = { url: resourceBundle._legacyUrl };
+      return runBeforeMiddlewares(resourceBundle.request, z, resourceBundle)
+        .then(request => {
+          // Do a _read_resource() from scripting.
+          const fullResourceEvent = {
+            name: 'search.resource',
+            key: '<%= KEY %>',
+            results
+          };
+          resourceBundle.request = request;
+          return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+        });
     })
     .then(results => {
       // WB would return a single record, but in CLI we expect an array
@@ -385,14 +401,19 @@ const getList = (z, bundle) => {
     .then(postSearchResult => {
       const results = postSearchResult;
 
-      // Do a _read_resource() from scripting.
-      const fullResourceEvent = {
-        name: 'search.resource',
-        key: '<%= KEY %>',
-        results
-      };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
-      return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+      resourceBundle.request = { url: resourceBundle._legacyUrl };
+      return runBeforeMiddlewares(resourceBundle.request, z, resourceBundle)
+        .then(request => {
+          // Do a _read_resource() from scripting.
+          const fullResourceEvent = {
+            name: 'search.resource',
+            key: '<%= KEY %>',
+            results
+          };
+          resourceBundle.request = request;
+          return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+        });
     })
     .then(results => {
       // WB would return a single record, but in CLI we expect an array
@@ -534,27 +555,38 @@ const getList = (z, bundle) => {
 
   bundle._legacyUrl = '<%= URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
   resourceBundle._legacyUrl = '<%= RESOURCE_URL %>';
 
-  // Do a _search() from scripting.
-  const fullSearchEvent = {
-    name: 'search.search',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullSearchEvent, z, bundle)
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _search() from scripting.
+      const fullSearchEvent = {
+        name: 'search.search',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullSearchEvent, z, bundle);
+    })
 <% if (resourceFullScripting) { %>
     .then(fullSearchResult => {
       const results = fullSearchResult;
 
-      // Do a _read_resource() from scripting.
-      const fullResourceEvent = {
-        name: 'search.resource',
-        key: '<%= KEY %>',
-        results
-      };
       resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
-      return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+      resourceBundle.request = { url: resourceBundle._legacyUrl };
+      return runBeforeMiddlewares(resourceBundle.request, z, resourceBundle)
+        .then(request => {
+          // Do a _read_resource() from scripting.
+          const fullResourceEvent = {
+            name: 'search.resource',
+            key: '<%= KEY %>',
+            results
+          };
+          resourceBundle.request = request;
+          return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+        });
     })
     .then(results => {
       // WB would return a single record, but in CLI we expect an array
@@ -710,14 +742,19 @@ const getList = (z, bundle) => {
 
       const results = z.JSON.parse(response.content);
 
-      // Do a _read_resource() from scripting.
-      const fullResourceEvent = {
-        name: 'search.resource',
-        key: '<%= KEY %>',
-        results
-      };
-      resourceBundle._legacyUrl = replaceVars(bundle._legacyUrl, resourceBundle, _.get(results, 0));
-      return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+      resourceBundle._legacyUrl = replaceVars(resourceBundle._legacyUrl, resourceBundle, _.get(results, 0));
+      resourceBundle.request = { url: resourceBundle._legacyUrl };
+      return runBeforeMiddlewares(resourceBundle.request, z, resourceBundle)
+        .then(request => {
+          // Do a _read_resource() from scripting.
+          const fullResourceEvent = {
+            name: 'search.resource',
+            key: '<%= KEY %>',
+            results
+          };
+          resourceBundle.request = request;
+          return legacyScriptingRunner.runEvent(fullResourceEvent, z, resourceBundle);
+        });
     })
     .then(results => {
       // WB would return a single record, but in CLI we expect an array
@@ -866,13 +903,19 @@ const getInputFields = (z, bundle) => {
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _custom_search_fields() from scripting.
-  const fullFieldsEvent = {
-    name: 'search.input',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _custom_search_fields() from scripting.
+      const fullFieldsEvent = {
+        name: 'search.input',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullFieldsEvent, z, bundle);
+    });
 };
 <% } else if (inputFieldPreScripting && !inputFieldPostScripting) { %>
 const getInputFields = (z, bundle) => {
@@ -966,13 +1009,19 @@ const getOutputFields = (z, bundle) => {
 
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _custom_search_result_fields() from scripting.
-  const fullResultFieldsEvent = {
-    name: 'search.output',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _custom_search_result_fields() from scripting.
+      const fullResultFieldsEvent = {
+        name: 'search.output',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullResultFieldsEvent, z, bundle);
+    });
 };
 <% } else if (outputFieldPreScripting && !outputFieldPostScripting) { %>
 const getOutputFields = (z, bundle) => {

--- a/scaffold/convert/trigger.template.js
+++ b/scaffold/convert/trigger.template.js
@@ -1,5 +1,9 @@
 // Trigger stub created by 'zapier convert'. This is just a stub - you will need to edit!
 const { replaceVars } = require('../utils');
+<% if (fullScripting) { %>
+  const { runBeforeMiddlewares } = require('../utils');
+<% } %>
+
 <%
 // Template for just _pre_poll()
 if (preScripting && !postScripting && !fullScripting) { %>
@@ -92,13 +96,19 @@ const getList = (z, bundle) => {
 
   bundle._legacyUrl = '<%= URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+  bundle.request = { url: bundle._legacyUrl };
 
-  // Do a _poll() from scripting.
-  const fullPollEvent = {
-    name: 'trigger.poll',
-    key: '<%= KEY %>'
-  };
-  return legacyScriptingRunner.runEvent(fullPollEvent, z, bundle);
+  return runBeforeMiddlewares(bundle.request, z, bundle)
+    .then(request => {
+      bundle.request = request;
+
+      // Do a _poll() from scripting.
+      const fullPollEvent = {
+        name: 'trigger.poll',
+        key: '<%= KEY %>'
+      };
+      return legacyScriptingRunner.runEvent(fullPollEvent, z, bundle);
+    });
 };
 <%
 }

--- a/scaffold/convert/utils.template.js
+++ b/scaffold/convert/utils.template.js
@@ -11,11 +11,6 @@ const replaceVars = (templateString, bundle, result) => {
   return _.template(templateString, options)(values);
 };
 
-// Check if an object is a Promise
-const isPromise = obj => {
-  return typeof obj === 'object' && typeof obj.then === 'function';
-};
-
 // Explicitly run App.beforeRequest middlewares in the app code. Only necessary
 // for WB scripting methods that send HTTP requests themselves, such as
 // KEY_poll, KEY_search, KEY_write, KEY_read_resource, KEY_custom_action_fields
@@ -23,12 +18,9 @@ const isPromise = obj => {
 const runBeforeMiddlewares = (request, z, bundle) => {
   const app = require('./');
 
-  const befores = app.beforeRequest ? app.beforeRequest : [];
+  const befores = app.beforeRequest || [];
   return befores.reduce((prevResult, before) => {
-    if (!isPromise(prevResult)) {
-      prevResult = Promise.resolve(prevResult);
-    }
-    return prevResult.then(newRequest => {
+    return Promise.resolve(prevResult).then(newRequest => {
       return before(newRequest, z, bundle);
     });
   }, request);

--- a/scaffold/convert/utils.template.js
+++ b/scaffold/convert/utils.template.js
@@ -11,6 +11,30 @@ const replaceVars = (templateString, bundle, result) => {
   return _.template(templateString, options)(values);
 };
 
+// Check if an object is a Promise
+const isPromise = obj => {
+  return typeof obj === 'object' && typeof obj.then === 'function';
+};
+
+// Explicitly run App.beforeRequest middlewares in the app code. Only necessary
+// for WB scripting methods that send HTTP requests themselves, such as
+// KEY_poll, KEY_search, KEY_write, KEY_read_resource, KEY_custom_action_fields
+// and KEY_custom_search_fields.
+const runBeforeMiddlewares = (request, z, bundle) => {
+  const app = require('./');
+
+  const befores = app.beforeRequest ? app.beforeRequest : [];
+  return befores.reduce((prevResult, before) => {
+    if (!isPromise(prevResult)) {
+      prevResult = Promise.resolve(prevResult);
+    }
+    return prevResult.then(newRequest => {
+      return before(newRequest, z, bundle);
+    });
+  }, request);
+};
+
 module.exports = {
-  replaceVars
+  replaceVars,
+  runBeforeMiddlewares
 };

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -18,7 +18,8 @@ const appsToConvert = [
   { id: 83195, name: 'search-or-create' },
   { id: 80444, name: 'custom-basic' },
   { id: 83073, name: 'send-in-json' },
-  { id: 83342, name: 'replace-vars' }
+  { id: 83342, name: 'replace-vars' },
+  { id: 88339, name: 'create-oauth' }
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 
@@ -26,7 +27,7 @@ const testConvertedApp = (appToConvert, rootTmpDir) => {
   const zapierCmd = path.resolve(__dirname, '../zapier.js');
   // Prepare all env variables the apps might need
   const exportCmd =
-    'export CLIENT_ID=1234 CLIENT_SECRET=asdf USERNAME=user PASSWORD=passwd API_KEY=anything-goes ACCESS_TOKEN=a_token REFRESH_TOKEN=a_refresh_token';
+    'export CLIENT_ID=1234 CLIENT_SECRET=asdf USERNAME=user PASSWORD=secret API_KEY=secret SESSION_KEY=secret ACCESS_TOKEN=a_token REFRESH_TOKEN=a_refresh_token';
 
   const logFile = path.resolve(__dirname, '..', `${appToConvert.name}.log`);
   const logStream = fse.createWriteStream(logFile);

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -235,6 +235,10 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(
           'const maybeIncludeAuth = (request, z, bundle) => {\n' +
+            '  if (!request.headers) {\n' +
+            '    request.headers = {};\n' +
+            '  }\n' +
+            '\n' +
             "  request.headers['Authorization'] = `AccessKey ${bundle.authData['api_key']}`;\n" +
             '\n' +
             '  return request;\n' +
@@ -307,6 +311,9 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
+  if (!request.headers) {
+    request.headers = {};
+  }
   request.headers['X-Token'] = bundle.authData.sessionKey;
 
   return request;
@@ -396,6 +403,9 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
+    if (!request.headers) {
+      request.headers = {};
+    }
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;
@@ -518,6 +528,9 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
+    if (!request.headers) {
+      request.headers = {};
+    }
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -8,7 +8,7 @@ const { printStarting, printDone } = require('./display');
 const { PACKAGE_VERSION } = require('../constants');
 
 const TEMPLATE_DIR = path.join(__dirname, '../../scaffold/convert');
-const ZAPIER_LEGACY_SCRIPTING_RUNNER_VERSION = '1.0.0';
+const ZAPIER_LEGACY_SCRIPTING_RUNNER_VERSION = '1.1.0';
 
 // map WB auth types to CLI
 const authTypeMap = {


### PR DESCRIPTION
In a WB app, we allow users to make HTTP requests with `z.request` themselves in "full" scripting methods like `KEY_poll`, `KEY_write`, and `KEY_search`. However, in a converted CLI app, the `z.request` used in `scripting.js` is not patched to apply `beforeRequest` middlewares. Without the middlewares, authentication won't work.

I spot all the full scripting methods and apply the `beforeRequest` middlewares by calling the newly-added function `runBeforeMiddlewares`.

This PR **MUST** go along with zapier/zapier-platform-legacy-scripting-runner#1.

To test, you can try converting a WB app that has full scripting methods and requires auth. Some example apps:

* 80182 - trigger scripting and session auth
* 82250 - search scripting and OAuth
* 88339 - create scripting and OAuth

You may test like this:

```
zapier convert 80182 trigger-session-auth
cd trigger-session-auth
npm install
npm link zapier-platform-legacy-scripting-runner
echo "ACCESS_TOKEN=a_token" > .environment
echo "SESSION_KEY=secret" >> .environment
zapier test
```