### PR TITLE
zapier convert: Be defensive about request.headers and request.params in middlewares

### DIFF
--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -2,11 +2,6 @@
 const { replaceVars } = require('./utils');
 <% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
-  <% if (query) { %>
-    request.params = request.params || {};
-  <% } else { %>
-    request.headers = request.headers || {};
-  <% } %>
 <%
   Object.keys(mapping).forEach(key => {
     let value = mapping[key];
@@ -29,7 +24,6 @@ const maybeIncludeAuth = (request, z, bundle) => {
   const username = replaceVars(mapping.username, bundle);
   const password = replaceVars(mapping.password, bundle);
   const encoded = Buffer.from(`${username}:${password}`).toString('base64');
-  request.headers = request.headers || {};
   request.headers.Authorization = `Basic ${encoded}`;
   return request;
 };
@@ -37,10 +31,8 @@ const maybeIncludeAuth = (request, z, bundle) => {
 
 if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <% if (query) { %>
-  request.params = request.params || {};
   request.params['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;;
 <% } else { %>
-  request.headers = request.headers || {};
   request.headers['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;
 <% } %>
   return request;
@@ -49,7 +41,6 @@ if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 
 if (before && oauth) { %>const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    request.headers = request.headers || {};
     request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
   }
   return request;

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -3,9 +3,7 @@ const { replaceVars } = require('./utils');
 <% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
   <% if (!query) { %>
-    if (!request.headers) {
-      request.headers = {};
-    }
+    request.headers = request.headers || {};
   <% } %>
 <%
   Object.keys(mapping).forEach(key => {
@@ -29,6 +27,7 @@ const maybeIncludeAuth = (request, z, bundle) => {
   const username = replaceVars(mapping.username, bundle);
   const password = replaceVars(mapping.password, bundle);
   const encoded = Buffer.from(`${username}:${password}`).toString('base64');
+  request.headers = request.headers || {};
   request.headers.Authorization = `Basic ${encoded}`;
   return request;
 };
@@ -38,9 +37,7 @@ if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <% if (query) { %>
   request.params['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;;
 <% } else { %>
-  if (!request.headers) {
-    request.headers = {};
-  }
+  request.headers = request.headers || {};
   request.headers['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;
 <% } %>
   return request;
@@ -49,9 +46,7 @@ if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 
 if (before && oauth) { %>const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    if (!request.headers) {
-      request.headers = {};
-    }
+    request.headers = request.headers || {};
     request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
   }
   return request;

--- a/scaffold/convert/header.template.js
+++ b/scaffold/convert/header.template.js
@@ -2,7 +2,9 @@
 const { replaceVars } = require('./utils');
 <% } %>
 <% if (before && !session && !oauth && !customBasic) { %>const maybeIncludeAuth = (request, z, bundle) => {
-  <% if (!query) { %>
+  <% if (query) { %>
+    request.params = request.params || {};
+  <% } else { %>
     request.headers = request.headers || {};
   <% } %>
 <%
@@ -35,6 +37,7 @@ const maybeIncludeAuth = (request, z, bundle) => {
 
 if (before && session) { %>const maybeIncludeAuth = (request, z, bundle) => {
 <% if (query) { %>
+  request.params = request.params || {};
   request.params['<%= Object.keys(mapping)[0] %>'] = bundle.authData.sessionKey;;
 <% } else { %>
   request.headers = request.headers || {};

--- a/scaffold/convert/utils.template.js
+++ b/scaffold/convert/utils.template.js
@@ -18,6 +18,10 @@ const replaceVars = (templateString, bundle, result) => {
 const runBeforeMiddlewares = (request, z, bundle) => {
   const app = require('./');
 
+  // Do it here so middlewares don't have to
+  request.params = request.params || {};
+  request.headers = request.headers || {};
+
   const befores = app.beforeRequest || [];
   return befores.reduce((prevResult, before) => {
     return Promise.resolve(prevResult).then(newRequest => {

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -270,6 +270,8 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(
           'const maybeIncludeAuth = (request, z, bundle) => {\n' +
+            '  request.params = request.params || {};\n' +
+            '\n' +
             "  request.params['api_key'] = `${bundle.authData['api_key']}`;\n" +
             '\n' +
             '  return request;\n' +

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -235,9 +235,7 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(
           'const maybeIncludeAuth = (request, z, bundle) => {\n' +
-            '  if (!request.headers) {\n' +
-            '    request.headers = {};\n' +
-            '  }\n' +
+            '  request.headers = request.headers || {};\n' +
             '\n' +
             "  request.headers['Authorization'] = `AccessKey ${bundle.authData['api_key']}`;\n" +
             '\n' +
@@ -311,9 +309,7 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  if (!request.headers) {
-    request.headers = {};
-  }
+  request.headers = request.headers || {};
   request.headers['X-Token'] = bundle.authData.sessionKey;
 
   return request;
@@ -403,9 +399,7 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    if (!request.headers) {
-      request.headers = {};
-    }
+    request.headers = request.headers || {};
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;
@@ -528,9 +522,7 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    if (!request.headers) {
-      request.headers = {};
-    }
+    request.headers = request.headers || {};
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -235,8 +235,6 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(
           'const maybeIncludeAuth = (request, z, bundle) => {\n' +
-            '  request.headers = request.headers || {};\n' +
-            '\n' +
             "  request.headers['Authorization'] = `AccessKey ${bundle.authData['api_key']}`;\n" +
             '\n' +
             '  return request;\n' +
@@ -270,8 +268,6 @@ describe('convert render functions', () => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(
           'const maybeIncludeAuth = (request, z, bundle) => {\n' +
-            '  request.params = request.params || {};\n' +
-            '\n' +
             "  request.params['api_key'] = `${bundle.authData['api_key']}`;\n" +
             '\n' +
             '  return request;\n' +
@@ -311,7 +307,6 @@ describe('convert render functions', () => {
 
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
-  request.headers = request.headers || {};
   request.headers['X-Token'] = bundle.authData.sessionKey;
 
   return request;
@@ -401,7 +396,6 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    request.headers = request.headers || {};
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;
@@ -524,7 +518,6 @@ const getSessionKey = (z, bundle) => {
       return convert.getHeader(wbDef).then(string => {
         string.should.eql(`const maybeIncludeAuth = (request, z, bundle) => {
   if (bundle.authData.access_token) {
-    request.headers = request.headers || {};
     request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
   }
   return request;


### PR DESCRIPTION
There are some occasions where the `request` object, which is passed into a `beforeRequest` middleware, doesn't have `.headers` or `.params` defined, especially when applying middlewares in app code with `runBeforeMiddlewares`. Let's be defensive about it in middlewares by adding `request.headers = request.headers || {}` or `request.params = request.params || {}` everywhere fits.