### PR TITLE
zapier convert: Respect auth field keys in test code

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -766,6 +766,8 @@ const renderAuthData = definition => {
   const authType = getAuthType(definition);
   let result;
   switch (authType) {
+    case 'api-header': // fall through
+    case 'api-query': // fall through
     case 'basic': {
       let lines = _.map(definition.auth_fields, (field, key) => {
         const upperKey = key.toUpperCase();
@@ -785,12 +787,6 @@ ${lines.join(',\n')}
       result = `{
         access_token: process.env.ACCESS_TOKEN,
         refresh_token: process.env.REFRESH_TOKEN
-      }`;
-      break;
-    case 'api-header': // Fall through
-    case 'api-query':
-      result = `{
-        apiKey: process.env.API_KEY
       }`;
       break;
     case 'session':


### PR DESCRIPTION
Currently, `zapier convert` always generates the following auth data in test code for API-key-authed WB apps:

```js
const bundle = {
  authData: {
      apiKey: process.env.API_KEY
  },
  // ...
}
```

This PR improves it so that the generated code respect the user's auth field key. So for example, if the auth field key is "my_api_key", it'll generate:

```js
const bundle = {
  authData: {
      my_api_key: process.env.MY_API_KEY
  },
  // ...
}
```