### PR TITLE
zapier convert: .environment -> .env

### DIFF
--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -43,7 +43,7 @@ const convert = (context, appid, location) => {
       `Finished! You may try \`npm install\` and then \`zapier test\` in "${location}" directory.`
     );
     context.line(
-      "Also, if your app has authentication, don't forget to edit the environment variables in the .environment file."
+      "Also, if your app has authentication, don't forget to edit the environment variables in the .env file."
     );
   });
 };

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1043,7 +1043,7 @@ const writeEnvironment = (legacyApp, newAppDir) => {
   if (!content) {
     return Promise.resolve(null);
   }
-  return createFile(content, '.environment', newAppDir);
+  return createFile(content, '.env', newAppDir);
 };
 
 const writeGitIgnore = newAppDir => {


### PR DESCRIPTION
Makes `zapier convert` generate `.env` instead of `.environment`. This is a follow-up PR to zapier/zapier-platform-core#70.