### PR TITLE
zapier convert: Fix 'CUSTOM_FIELDS_URL is not defined' error

### DIFF
--- a/scaffold/convert/create.template.js
+++ b/scaffold/convert/create.template.js
@@ -154,9 +154,14 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
   bundle.request = { url: bundle._legacyUrl };
+<% } else { %>
+  bundle._legacyUrl = null;
+  bundle.request = {};
+<% } %>
 
   return runBeforeMiddlewares(bundle.request, z, bundle)
     .then(request => {
@@ -175,8 +180,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_action_fields() from scripting.
   const preFieldsEvent = {
@@ -195,8 +204,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_action_fields() from scripting.
   const preFieldsEvent = {
@@ -222,8 +235,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -261,9 +278,14 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
   bundle.request = { url: bundle._legacyUrl };
+<% } else { %>
+  bundle._legacyUrl = null;
+  bundle.request = {};
+<% } %>
 
   return runBeforeMiddlewares(bundle.request, z, bundle)
     .then(request => {
@@ -282,8 +304,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -302,8 +328,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_action_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -329,8 +359,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   const responsePromise = z.request({
     url: bundle._legacyUrl

--- a/scaffold/convert/search.template.js
+++ b/scaffold/convert/search.template.js
@@ -901,9 +901,14 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
   bundle.request = { url: bundle._legacyUrl };
+<% } else { %>
+  bundle._legacyUrl = null;
+  bundle.request = {};
+<% } %>
 
   return runBeforeMiddlewares(bundle.request, z, bundle)
     .then(request => {
@@ -922,8 +927,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
@@ -942,8 +951,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_search_fields() from scripting.
   const preFieldsEvent = {
@@ -969,8 +982,12 @@ const getInputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   const responsePromise = z.request({
     url: bundle._legacyUrl
@@ -1007,9 +1024,14 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
   bundle.request = { url: bundle._legacyUrl };
+<% } else { %>
+  bundle._legacyUrl = null;
+  bundle.request = {};
+<% } %>
 
   return runBeforeMiddlewares(bundle.request, z, bundle)
     .then(request => {
@@ -1028,8 +1050,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -1048,8 +1074,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_search_result_fields() from scripting.
   const preResultFieldsEvent = {
@@ -1075,8 +1105,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_RESULT_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_RESULT_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   const responsePromise = z.request({
     url: bundle._legacyUrl

--- a/scaffold/convert/trigger.template.js
+++ b/scaffold/convert/trigger.template.js
@@ -133,8 +133,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
@@ -153,8 +157,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   // Do a _pre_custom_trigger_fields() from scripting.
   const preResultFieldsEvent = {
@@ -180,8 +188,12 @@ const getOutputFields = (z, bundle) => {
   const scripting = require('../scripting');
   const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);
 
+<% if (CUSTOM_FIELDS_URL) { %>
   bundle._legacyUrl = '<%= CUSTOM_FIELDS_URL %>';
   bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
+<% } else { %>
+  bundle._legacyUrl = null;
+<% } %>
 
   const responsePromise = z.request({
     url: bundle._legacyUrl

--- a/scripts/test-convert.js
+++ b/scripts/test-convert.js
@@ -19,7 +19,8 @@ const appsToConvert = [
   { id: 80444, name: 'custom-basic' },
   { id: 83073, name: 'send-in-json' },
   { id: 83342, name: 'replace-vars' },
-  { id: 88339, name: 'create-oauth' }
+  { id: 88339, name: 'create-oauth' },
+  { id: 88722, name: 'no-custom-fields-url' }
   // TODO: Add more apps that use different scripting methods, as we start to support them
 ];
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -704,6 +704,8 @@ const renderStep = (type, definition, key, legacyApp) => {
     SAMPLE_FIELDS: sampleFields,
     SAMPLE: sample,
     URL: url,
+    CUSTOM_FIELDS_URL: null,
+    CUSTOM_FIELDS_RESULT_URL: null,
     scripting: stepMeta.hasScripting,
     preScripting: stepMeta.hasPreScripting,
     postScripting: stepMeta.hasPostScripting,


### PR DESCRIPTION
Fixes PDE-135. The bug happens when the WB app has custom fields scripting but doesn't specify a custom fields URL.