### PR TITLE
Add rawError to callAPI

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -41,7 +41,7 @@ const readCredentials = (explodeIfMissing = true) => {
 };
 
 // Calls the underlying platform REST API with proper authentication.
-const callAPI = (route, options, displayError = true) => {
+const callAPI = (route, options, displayError = true, rawError = false) => {
   options = options || {};
   const url = options.url || constants.ENDPOINT + route;
 
@@ -100,9 +100,18 @@ const callAPI = (route, options, displayError = true) => {
       }
 
       if (hitError) {
-        throw new Error(
-          `"${requestOptions.url}" returned "${res.status}" saying "${errors}"`
-        );
+        const niceMessage = `"${requestOptions.url}" returned "${
+          res.status
+        }" saying "${errors}"`;
+
+        if (rawError) {
+          res.text = text;
+          res.json = JSON.parse(text);
+          res.errText = niceMessage;
+          return Promise.reject(res);
+        } else {
+          throw new Error(niceMessage);
+        }
       }
 
       return JSON.parse(text);


### PR DESCRIPTION
addresses [PDE-138](https://zapierorg.atlassian.net/browse/PDE-138)

Previously, when the server returned a 400+ error code, we would package the error message up and throw it. This is normally useful, but when we get back a json with errors and want to process them, we were (previously) unable to. It also more correctly identifies when then the issue is an activation one.

This adds a param to `callAPI` that returns the response object instead of directly throwing an error. This is most relevant in `promote`, but it will potentially be useful in other places as well. While I was there, I make some of the language more clear too.

Before: 

![](https://cdn.zapier.com/storage/photos/e56f91fcd70fe2edeb26db8f0a3c7c02.png)

After:

![](https://cdn.zapier.com/storage/photos/2bc02a16532314f50bb71a377cb93e45.png)

![](https://cdn.zapier.com/storage/photos/300b32b588f8e7faa4f912b8dfcd58c0.png)
**Merging Notes**
* This depends on https://github.com/zapier/zapier/pull/16441, so it may not get merged right away.
* this is going to cause a messy merge with #247, I'll handle that when we get to it. 