### PR TITLE
Less Nagging

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -1366,39 +1366,34 @@ source ~/.bash_completion.d/_zapier
 
 Finally, restart your shell and start hitting TAB with the `zapier` command!
 
-## Upgrading Zapier Platform CLI or Zapier Platform Core
+## The Zapier Platform Packages
 
-The CLI version of the Platform has 3 public packages:
+The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.
 
-- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli): This is the `zapier` command. Should be installed with `npm install -g zapier-platform-cli` and is used to interact with your app and Zapier, but doesn't run in nor is included by your app.
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commaonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
 
-- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core): This is what allows your app to interact with Zapier. Apps require this package in their `package.json` file, and a specific version by design, so you can keep using an older "core" version without having to upgrade your code, but still being able to update your app. Should be installed with `npm install` in your app. You should manually keep this version number in sync with your `zapier-platform-cli` global one, but it's not required for all upgrades.
+- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core) is what allows your app to interact with Zapier. It holds the `z` object and app tester code. Your app depends on a specific version of `zapier-platform-core` in the `package.json` file. It's installed via `npm install` along with the rest of your app's dependencies.
 
-- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema): This is a separate package for maintainability purposes. It's a dependency installed automatically by `zapier-platform-core`. It's basically the package that enforces app schemas to match what Zapier has in the backend.
+- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema) enforces app structure behind the scenes. It's a dependency of `core`, so it will be installed automatically.
 
-### Upgrading Zapier Platform CLI
+### Updating
 
-Check your version with `$ zapier --version` and update with `$ npm -g update zapier-platform-cli`.
+The Zapier platform and its tools are under active development While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-You can also [look at the Changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to understand what changed between versions.
+Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's platform version, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
 
-#### When to Update CLI
+<!-- TODO: if we decouple releases, change this -->
+The most recently released version of `cli` and `core` is `PACKAGE_VERSION`. You can see the versions you're working with by running `zapier -v`.
 
-You should keep your `zapier-platform-cli` global package up-to-date to get the latest features and bug fixes for interacting with your app, but it's not mandatory. You should be able to use any publicly available `zapier-platform-cli` version.
+To update `cli`, run `npm install -g zapier-platform-cli`.
 
-### Upgrading Zapier Platform Core
+To update the version of `core` your app depends on, set the `zapier-platform-core` dependency in your `package.json` to a version listed [here](https://github.com/zapier/zapier-platform-core/releases) and run `npm install`.
 
-Open your app's `package.json` file and update the number for the `zapier-platform-core` entry to what the latest public version is. You can see it on the right side of the [NPM registry page](https://www.npmjs.com/package/zapier-platform-core). After that you should be able to run `npm update` and get the latest goodies!
-
-#### When To Update Core
-
-You should keep your `zapier-platform-core` package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it's not mandatory. You should be able to use any publicly available `zapier-platform-core` version.
-
-While not always required, it's also recommended you use the same `zapier-platform-cli` global package as the app's `zapier-platform-core` one, to ensure maximum compatibility.
+For maximum compatibility, keep the versions of `cli` and `core` in sync.
 
 ## Development of the CLI
 
-This section is only relevant if you're editing the `zapier-platform-cli` package
+This section is only relevant if you're editing the `zapier-platform-cli` package itself.
 
 ### Commands
 

--- a/README-source.md
+++ b/README-source.md
@@ -471,7 +471,7 @@ In some cases, it might be necessary to provide fields that are dynamically gene
 [insert-file:./snippets/custom-fields.js]
 ```
 
-Additionally, if there is a field that affects the generation of dynamic fields, you can set the `altersDynamicFields: true` property. This informs the Zapier UI that whenver the value of that field changes, fields need to be recomputed. An example could be a static dropdown of "dessert type" that will change whether the function that generates dynamic fields includes a field "with sprinkles."
+Additionally, if there is a field that affects the generation of dynamic fields, you can set the `altersDynamicFields: true` property. This informs the Zapier UI that whenever the value of that field changes, fields need to be recomputed. An example could be a static dropdown of "dessert type" that will change whether the function that generates dynamic fields includes a field "with sprinkles."
 
 ```javascript
 [insert-file:./snippets/alters-dynamic-fields.js]
@@ -982,7 +982,7 @@ various kinds of errors occur.
 
 Errors due to a misconfiguration in a user's Zap should be handled in your app
 by throwing a standard JavaScript `Error` with a user-friendly message.
-Typically, this will be prettifying 4xx responses or API's that return errors as
+Typically, this will be prettifying 4xx responses or APIs that return errors as
 200s with a payload that describes the error.
 
 Example: `throw new Error('Your error message.');`
@@ -1370,7 +1370,7 @@ Finally, restart your shell and start hitting TAB with the `zapier` command!
 
 The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.
 
-- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commaonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
 
 - [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core) is what allows your app to interact with Zapier. It holds the `z` object and app tester code. Your app depends on a specific version of `zapier-platform-core` in the `package.json` file. It's installed via `npm install` along with the rest of your app's dependencies.
 
@@ -1378,9 +1378,9 @@ The Zapier Platform consists of 3 npm packages that are released simultaneously 
 
 ### Updating
 
-The Zapier platform and its tools are under active development While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
+The Zapier platform and its tools are under active development. While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's platform version, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
+Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's `platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
 
 <!-- TODO: if we decouple releases, change this -->
 The most recently released version of `cli` and `core` is `PACKAGE_VERSION`. You can see the versions you're working with by running `zapier -v`.

--- a/README.md
+++ b/README.md
@@ -940,7 +940,7 @@ const App = {
 
 ```
 
-Additionally, if there is a field that affects the generation of dynamic fields, you can set the `altersDynamicFields: true` property. This informs the Zapier UI that whenver the value of that field changes, fields need to be recomputed. An example could be a static dropdown of "dessert type" that will change whether the function that generates dynamic fields includes a field "with sprinkles."
+Additionally, if there is a field that affects the generation of dynamic fields, you can set the `altersDynamicFields: true` property. This informs the Zapier UI that whenever the value of that field changes, fields need to be recomputed. An example could be a static dropdown of "dessert type" that will change whether the function that generates dynamic fields includes a field "with sprinkles."
 
 ```javascript
 module.exports = {
@@ -1788,7 +1788,7 @@ various kinds of errors occur.
 
 Errors due to a misconfiguration in a user's Zap should be handled in your app
 by throwing a standard JavaScript `Error` with a user-friendly message.
-Typically, this will be prettifying 4xx responses or API's that return errors as
+Typically, this will be prettifying 4xx responses or APIs that return errors as
 200s with a payload that describes the error.
 
 Example: `throw new Error('Your error message.');`
@@ -2376,7 +2376,7 @@ Finally, restart your shell and start hitting TAB with the `zapier` command!
 
 The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.
 
-- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commaonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
 
 - [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core) is what allows your app to interact with Zapier. It holds the `z` object and app tester code. Your app depends on a specific version of `zapier-platform-core` in the `package.json` file. It's installed via `npm install` along with the rest of your app's dependencies.
 
@@ -2384,9 +2384,9 @@ The Zapier Platform consists of 3 npm packages that are released simultaneously 
 
 ### Updating
 
-The Zapier platform and its tools are under active development While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
+The Zapier platform and its tools are under active development. While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's platform version, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
+Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's `platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
 
 <!-- TODO: if we decouple releases, change this -->
 The most recently released version of `cli` and `core` is `5.0.0`. You can see the versions you're working with by running `zapier -v`.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,8 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 - [Command Line Tab Completion](#command-line-tab-completion)
   * [Zsh Completion Script](#zsh-completion-script)
   * [Bash Completion Script](#bash-completion-script)
-- [Upgrading Zapier Platform CLI or Zapier Platform Core](#upgrading-zapier-platform-cli-or-zapier-platform-core)
-  * [Upgrading Zapier Platform CLI](#upgrading-zapier-platform-cli)
-    + [When to Update CLI](#when-to-update-cli)
-  * [Upgrading Zapier Platform Core](#upgrading-zapier-platform-core)
-    + [When To Update Core](#when-to-update-core)
+- [The Zapier Platform Packages](#the-zapier-platform-packages)
+  * [Updating](#updating)
 - [Development of the CLI](#development-of-the-cli)
   * [Commands](#commands)
   * [Publishing of the CLI (after merging)](#publishing-of-the-cli-after-merging)
@@ -2375,39 +2372,34 @@ source ~/.bash_completion.d/_zapier
 
 Finally, restart your shell and start hitting TAB with the `zapier` command!
 
-## Upgrading Zapier Platform CLI or Zapier Platform Core
+## The Zapier Platform Packages
 
-The CLI version of the Platform has 3 public packages:
+The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.
 
-- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli): This is the `zapier` command. Should be installed with `npm install -g zapier-platform-cli` and is used to interact with your app and Zapier, but doesn't run in nor is included by your app.
+- [`zapier-platform-cli`](https://github.com/zapier/zapier-platform-cli) is the code that powers the `zapier` command. You use it most commaonly with the `test`, `scaffold`, and `push` commands. It's installed with `npm install -g zapier-platform-cli` and does not correspond to a particular app.
 
-- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core): This is what allows your app to interact with Zapier. Apps require this package in their `package.json` file, and a specific version by design, so you can keep using an older "core" version without having to upgrade your code, but still being able to update your app. Should be installed with `npm install` in your app. You should manually keep this version number in sync with your `zapier-platform-cli` global one, but it's not required for all upgrades.
+- [`zapier-platform-core`](https://github.com/zapier/zapier-platform-core) is what allows your app to interact with Zapier. It holds the `z` object and app tester code. Your app depends on a specific version of `zapier-platform-core` in the `package.json` file. It's installed via `npm install` along with the rest of your app's dependencies.
 
-- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema): This is a separate package for maintainability purposes. It's a dependency installed automatically by `zapier-platform-core`. It's basically the package that enforces app schemas to match what Zapier has in the backend.
+- [`zapier-platform-schema`](https://github.com/zapier/zapier-platform-schema) enforces app structure behind the scenes. It's a dependency of `core`, so it will be installed automatically.
 
-### Upgrading Zapier Platform CLI
+### Updating
 
-Check your version with `$ zapier --version` and update with `$ npm -g update zapier-platform-cli`.
+The Zapier platform and its tools are under active development While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-You can also [look at the Changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to understand what changed between versions.
+Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's platform version, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
 
-#### When to Update CLI
+<!-- TODO: if we decouple releases, change this -->
+The most recently released version of `cli` and `core` is `5.0.0`. You can see the versions you're working with by running `zapier -v`.
 
-You should keep your `zapier-platform-cli` global package up-to-date to get the latest features and bug fixes for interacting with your app, but it's not mandatory. You should be able to use any publicly available `zapier-platform-cli` version.
+To update `cli`, run `npm install -g zapier-platform-cli`.
 
-### Upgrading Zapier Platform Core
+To update the version of `core` your app depends on, set the `zapier-platform-core` dependency in your `package.json` to a version listed [here](https://github.com/zapier/zapier-platform-core/releases) and run `npm install`.
 
-Open your app's `package.json` file and update the number for the `zapier-platform-core` entry to what the latest public version is. You can see it on the right side of the [NPM registry page](https://www.npmjs.com/package/zapier-platform-core). After that you should be able to run `npm update` and get the latest goodies!
-
-#### When To Update Core
-
-You should keep your `zapier-platform-core` package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it's not mandatory. You should be able to use any publicly available `zapier-platform-core` version.
-
-While not always required, it's also recommended you use the same `zapier-platform-cli` global package as the app's `zapier-platform-core` one, to ensure maximum compatibility.
+For maximum compatibility, keep the versions of `cli` and `core` in sync.
 
 ## Development of the CLI
 
-This section is only relevant if you're editing the `zapier-platform-cli` package
+This section is only relevant if you're editing the `zapier-platform-cli` package itself.
 
 ### Commands
 

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -754,7 +754,7 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 <p>Note: this doesn&apos;t register or deploy the app with Zapier - try <code>zapier register &quot;Example&quot;</code> and <code>zapier push</code> for that!</p>
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><code>path [value]</code> -- <strong>required</strong>,</li>
-<li><code>--template={minimal,resource,trigger,create,search,middleware,basic-auth,custom-auth,oauth2,session-auth,babel,rest-hooks,files}</code> -- <em>optional</em>, select a starting app template. Default is <code>minimal</code></li>
+<li><code>--template={minimal,resource,trigger,create,search,middleware,basic-auth,custom-auth,oauth2,session-auth,babel,rest-hooks,files,github}</code> -- <em>optional</em>, select a starting app template. Default is <code>minimal</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -948,7 +948,7 @@ All personal keys deactivated - now try `zapier login` to login again.
 <li><code>--status={any,success,error}</code> -- <em>optional</em>, display only success logs (status code &lt; 400 / info) or error (status code &gt; 400 / tracebacks). Default is <code>any</code></li>
 <li><code>--type={console,http}</code> -- <em>optional</em>, display only console or http logs. Default is <code>console</code></li>
 <li><code>--detailed</code> -- <em>optional</em>, show detailed logs (like request/response body and headers)</li>
-<li><code>--user=user@example.com</code> -- <em>optional</em>, display only this user&apos;s logs. Default is <code>me</code></li>
+<li><a href="mailto:`--user=user@example.com">`--user=user@example.com</a><code>-- _optional_, display only this user&apos;s logs. Default is</code>me`</li>
 <li><code>--limit=50</code> -- <em>optional</em>, control the maximum result size. Default is <code>50</code></li>
 <li><code>--format={plain,json,raw,row,table,small}</code> -- <em>optional</em>, display format. Default is <code>table</code></li>
 <li><code>--help</code> -- <em>optional</em>, prints this help text</li>
@@ -1029,12 +1029,13 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http --detailed --format
 <p>Migrate users from one version of your app to another.</p>
 </blockquote><p>  <strong>Usage:</strong> <code>zapier migrate 1.0.0 1.0.1 [10%]</code></p><p>Starts a migration to move users between different versions of your app. You may also &quot;revert&quot; by simply swapping the from/to verion strings in the command line arguments (IE: <code>zapier migrate 1.0.1 1.0.0</code>).</p><p>Only migrate users between non-breaking versions, use <code>zapier deprecate</code> if you have breaking changes!</p><p>Migrations can take between 5-10 minutes, so be patient and check <code>zapier history</code> to track the status</p><p>Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.</p><blockquote>
 <p>Tip! We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.</p>
+</blockquote><blockquote>
 <p>Tip 2! You can migrate a single user by using <code>--user</code> (IE: <code>zapier migrate 1.0.0 1.0.1 --user=user@example.com</code>).</p>
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><code>fromVersion [1.0.0]</code> -- <strong>required</strong>, the version <strong>from</strong> which to migrate users</li>
 <li><code>toVersion [1.0.1]</code> -- <strong>required</strong>, the version <strong>to</strong> which to migrate users</li>
 <li><code>percent [100%]</code> -- <em>optional</em>, percent of users to migrate. Default is <code>100%</code></li>
-<li><code>--user=user@example.com</code> -- <em>optional</em>, migrate only this user</li>
+<li><a href="mailto:`--user=user@example.com">`--user=user@example.com</a>` -- <em>optional</em>, migrate only this user</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -429,7 +429,7 @@ After running this, you'll have a new example app in your directory. If you re-r
 **Arguments**
 
 * `path [value]` -- **required**,
-* `--template={minimal,resource,trigger,create,search,middleware,basic-auth,custom-auth,oauth2,session-auth,babel,rest-hooks,files}` -- _optional_, select a starting app template. Default is `minimal`
+* `--template={minimal,resource,trigger,create,search,middleware,basic-auth,custom-auth,oauth2,session-auth,babel,rest-hooks,files,github}` -- _optional_, select a starting app template. Default is `minimal`
 
 ```bash
 $ zapier init example-app --template=minimal

--- a/docs/index.html
+++ b/docs/index.html
@@ -1817,7 +1817,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Additionally, if there is a field that affects the generation of dynamic fields, you can set the <code>altersDynamicFields: true</code> property. This informs the Zapier UI that whenver the value of that field changes, fields need to be recomputed. An example could be a static dropdown of &quot;dessert type&quot; that will change whether the function that generates dynamic fields includes a field &quot;with sprinkles.&quot;</p>
+      <p>Additionally, if there is a field that affects the generation of dynamic fields, you can set the <code>altersDynamicFields: true</code> property. This informs the Zapier UI that whenever the value of that field changes, fields need to be recomputed. An example could be a static dropdown of &quot;dessert type&quot; that will change whether the function that generates dynamic fields includes a field &quot;with sprinkles.&quot;</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-javascript"><span class="hljs-built_in">module</span>.exports = {
@@ -3208,7 +3208,7 @@ various kinds of errors occur.</p>
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Errors due to a misconfiguration in a user&apos;s Zap should be handled in your app
 by throwing a standard JavaScript <code>Error</code> with a user-friendly message.
-Typically, this will be prettifying 4xx responses or API&apos;s that return errors as
+Typically, this will be prettifying 4xx responses or APIs that return errors as
 200s with a payload that describes the error.</p><p>Example: <code>throw new Error(&apos;Your error message.&apos;);</code></p><p>A couple best practices to keep in mind:</p><ul>
 <li>Elaborate on terse messages. &quot;not_authenticated&quot; -&gt; &quot;Your API Key is invalid. Please reconnect your account.&quot;</li>
 <li>If the error calls out a specific field, surface that information to the user. &quot;Invalid Request&quot; -&gt; &quot;contact name is invalid&quot;</li>
@@ -4159,7 +4159,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.</p><ul>
-<li><p><a href="https://github.com/zapier/zapier-platform-cli"><code>zapier-platform-cli</code></a> is the code that powers the <code>zapier</code> command. You use it most commaonly with the <code>test</code>, <code>scaffold</code>, and <code>push</code> commands. It&apos;s installed with <code>npm install -g zapier-platform-cli</code> and does not correspond to a particular app.</p>
+<li><p><a href="https://github.com/zapier/zapier-platform-cli"><code>zapier-platform-cli</code></a> is the code that powers the <code>zapier</code> command. You use it most commonly with the <code>test</code>, <code>scaffold</code>, and <code>push</code> commands. It&apos;s installed with <code>npm install -g zapier-platform-cli</code> and does not correspond to a particular app.</p>
 </li>
 <li><p><a href="https://github.com/zapier/zapier-platform-core"><code>zapier-platform-core</code></a> is what allows your app to interact with Zapier. It holds the <code>z</code> object and app tester code. Your app depends on a specific version of <code>zapier-platform-core</code> in the <code>package.json</code> file. It&apos;s installed via <code>npm install</code> along with the rest of your app&apos;s dependencies.</p>
 </li>
@@ -4183,7 +4183,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The Zapier platform and its tools are under active development While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never <em>have</em> to upgrade your app&apos;s platform version, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md">changelog</a> to see what new features and bux fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <code>5.0.0</code>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://github.com/zapier/zapier-platform-core/releases">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
+      <p>The Zapier platform and its tools are under active development. While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never <em>have</em> to upgrade your app&apos;s <code>platform-core</code> dependency, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md">changelog</a> to see what new features and bux fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <code>5.0.0</code>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://github.com/zapier/zapier-platform-core/releases">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -365,15 +365,8 @@ a code {
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
 </ul>
 </li>
-<li><a href="#upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</a><ul>
-<li><a href="#upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</a><ul>
-<li><a href="#when-to-update-cli">When to Update CLI</a></li>
-</ul>
-</li>
-<li><a href="#upgrading-zapier-platform-core">Upgrading Zapier Platform Core</a><ul>
-<li><a href="#when-to-update-core">When To Update Core</a></li>
-</ul>
-</li>
+<li><a href="#the-zapier-platform-packages">The Zapier Platform Packages</a><ul>
+<li><a href="#updating">Updating</a></li>
 </ul>
 </li>
 <li><a href="#development-of-the-cli">Development of the CLI</a><ul>
@@ -552,15 +545,8 @@ a code {
 <li><a href="#bash-completion-script">Bash Completion Script</a></li>
 </ul>
 </li>
-<li><a href="#upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</a><ul>
-<li><a href="#upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</a><ul>
-<li><a href="#when-to-update-cli">When to Update CLI</a></li>
-</ul>
-</li>
-<li><a href="#upgrading-zapier-platform-core">Upgrading Zapier Platform Core</a><ul>
-<li><a href="#when-to-update-core">When To Update Core</a></li>
-</ul>
-</li>
+<li><a href="#the-zapier-platform-packages">The Zapier Platform Packages</a><ul>
+<li><a href="#updating">Updating</a></li>
 </ul>
 </li>
 <li><a href="#development-of-the-cli">Development of the CLI</a><ul>
@@ -889,6 +875,7 @@ npm install
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
+
 </code></pre>
     </div>
   </div>
@@ -1087,6 +1074,7 @@ zapier convert 1234 my-app
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Your CLI app will be created and you can continue working on it.</p><blockquote>
 <p>Since v3.3.0, <code>zapier convert</code> has been improved a lot. But this is still in an alpha state - you&apos;ll likely have to edit the code to make it work.</p>
+</blockquote><blockquote>
 <p>Note - there is no way to convert a CLI app to a Web Builder app and we do not plan on implementing this.</p>
 </blockquote>
     </div>
@@ -1128,6 +1116,7 @@ zapier convert 1234 my-app
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Useful if your app requires two pieces of information to authentication: <code>username</code> and <code>password</code> which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-basic-auth">https://github.com/zapier/zapier-platform-example-app-basic-auth</a> for a working example app for basic auth.</p>
+</blockquote><blockquote>
 <p>Note: if you do the common API Key pattern like <code>Authorization: Basic APIKEYHERE:x</code> you should look at the &quot;Custom&quot; authentication method instead.</p>
 </blockquote>
     </div>
@@ -1147,6 +1136,7 @@ zapier convert 1234 my-app
   authentication: authentication
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -1203,6 +1193,7 @@ zapier convert 1234 my-app
   <span class="hljs-attr">beforeRequest</span>: [addApiKeyToHeader]
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -1240,6 +1231,7 @@ zapier convert 1234 my-app
   authentication: authentication
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -1334,6 +1326,7 @@ zapier convert 1234 my-app
   <span class="hljs-attr">afterResponse</span>: [sessionRefreshIf401]
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -1451,6 +1444,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
+
 </code></pre>
     </div>
   </div>
@@ -1495,6 +1489,7 @@ read, and search operations on that resource.</p>
     <span class="hljs-comment">//...</span>
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1557,6 +1552,7 @@ For now, let&apos;s focus on two:</p><ul>
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1591,6 +1587,7 @@ For now, let&apos;s focus on two:</p><ul>
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1646,6 +1643,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1655,8 +1653,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <p>You can find more details on the definition for each by looking at the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#triggerschema">Trigger Schema</a>,
 <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#searchschema">Search Schema</a>, and <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#createschema">Create Schema</a>.</p><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-trigger">https://github.com/zapier/zapier-platform-example-app-trigger</a> for a working example app using triggers.</p>
+</blockquote><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-rest-hooks">https://github.com/zapier/zapier-platform-example-app-rest-hooks</a> for a working example app using REST hook triggers.</p>
+</blockquote><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-search">https://github.com/zapier/zapier-platform-example-app-search</a> for a working example app using searches.</p>
+</blockquote><blockquote>
 <p>Example App: check out <a href="https://github.com/zapier/zapier-platform-example-app-create">https://github.com/zapier/zapier-platform-example-app-create</a> for a working example app using creates.</p>
 </blockquote>
     </div>
@@ -1756,6 +1757,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1808,6 +1810,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1844,6 +1847,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1902,6 +1906,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -1972,6 +1977,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -2434,6 +2440,7 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>This is a popular way to provide <code>process.env.ACCESS_TOKEN || bundle.authData.access_token</code> for convenient testing.</p>
+</blockquote><blockquote>
 <p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env 1.0.0 foo_bar 1234</code> with <code>process.env.FOO_BAR</code>.</p>
 </blockquote>
     </div>
@@ -2492,6 +2499,7 @@ zapier env 1.0.0
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -2573,6 +2581,7 @@ zapier env 1.0.0
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -2633,6 +2642,7 @@ zapier env 1.0.0
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -2682,6 +2692,7 @@ zapier env 1.0.0
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -2736,6 +2747,7 @@ zapier env 1.0.0
   <span class="hljs-attr">afterResponse</span>: [mustBe200, autoParseJson]
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -2774,7 +2786,7 @@ zapier env 1.0.0
 <li><code>compress</code>: support gzip/deflate content encoding. Set to <code>false</code> to disable. Default is <code>true</code>.</li>
 <li><code>agent</code>: Node.js <code>http.Agent</code> instance, allows custom proxy, certificate etc. Default is <code>null</code>.</li>
 <li><code>timeout</code>: request / response timeout in ms. Set to <code>0</code> to disable (OS limit still applies), timeout reset on <code>redirect</code>. Default is <code>0</code> (disabled).</li>
-<li><code>size</code>: maximum response body size in bytes. Set to <code>0`` to disable. Default is</code>0` (disabled).</li>
+<li><code>size</code>: maximum response body size in bytes. Set to <code>0`</code> to disable. Default is <code>0</code> (disabled).</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -2916,6 +2928,7 @@ zapier env 1.0.0
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
+
 </code></pre>
     </div>
   </div>
@@ -3023,6 +3036,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
+
 </code></pre>
     </div>
   </div>
@@ -3327,6 +3341,7 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
     });
   });
 });
+
 </code></pre>
     </div>
   </div>
@@ -3410,6 +3425,7 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
     });
   });
 });
+
 </code></pre>
     </div>
   </div>
@@ -3603,6 +3619,7 @@ zapier <span class="hljs-built_in">test</span>
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>During the <code>zapier build</code> or <code>zapier push</code> step - we&apos;ll copy all your code to <code>/tmp</code> folder and do a fresh re-install of modules.</p><blockquote>
 <p>Note: If your package isn&apos;t being pushed correctly (IE: you get &quot;Error: Cannot find module &apos;whatever&apos;&quot; in production), try adding the <code>--disable-dependency-detection</code> flag to <code>zapier push</code>.</p>
+</blockquote><blockquote>
 <p>Note 2: You can also try adding a &quot;includeInBuild&quot; array property (with paths to include, which will be evaluated to RegExp, with a case insensitive flag) to your <code>.zapierapprc</code> file, to make it look like:</p>
 </blockquote>
     </div>
@@ -3615,6 +3632,7 @@ zapier <span class="hljs-built_in">test</span>
     <span class="hljs-string">&quot;testing.json&quot;</span>
   ]
 }
+
 </code></pre>
     </div>
   </div>
@@ -3805,6 +3823,7 @@ npm run zapier-push
   ]
   <span class="hljs-comment">// ...</span>
 };
+
 </code></pre>
     </div>
   </div>
@@ -3870,6 +3889,7 @@ npm run zapier-push
     <span class="hljs-attr">perform</span>: performPaging
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -3918,6 +3938,7 @@ npm run zapier-push
     }
   }
 };
+
 </code></pre>
     </div>
   </div>
@@ -4128,7 +4149,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h2 id="upgrading-zapier-platform-cli-or-zapier-platform-core">Upgrading Zapier Platform CLI or Zapier Platform Core</h2>
+      <h2 id="the-zapier-platform-packages">The Zapier Platform Packages</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4137,12 +4158,12 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The CLI version of the Platform has 3 public packages:</p><ul>
-<li><p><a href="https://github.com/zapier/zapier-platform-cli"><code>zapier-platform-cli</code></a>: This is the <code>zapier</code> command. Should be installed with <code>npm install -g zapier-platform-cli</code> and is used to interact with your app and Zapier, but doesn&apos;t run in nor is included by your app.</p>
+      <p>The Zapier Platform consists of 3 npm packages that are released simultaneously as a trio.</p><ul>
+<li><p><a href="https://github.com/zapier/zapier-platform-cli"><code>zapier-platform-cli</code></a> is the code that powers the <code>zapier</code> command. You use it most commaonly with the <code>test</code>, <code>scaffold</code>, and <code>push</code> commands. It&apos;s installed with <code>npm install -g zapier-platform-cli</code> and does not correspond to a particular app.</p>
 </li>
-<li><p><a href="https://github.com/zapier/zapier-platform-core"><code>zapier-platform-core</code></a>: This is what allows your app to interact with Zapier. Apps require this package in their <code>package.json</code> file, and a specific version by design, so you can keep using an older &quot;core&quot; version without having to upgrade your code, but still being able to update your app. Should be installed with <code>npm install</code> in your app. You should manually keep this version number in sync with your <code>zapier-platform-cli</code> global one, but it&apos;s not required for all upgrades.</p>
+<li><p><a href="https://github.com/zapier/zapier-platform-core"><code>zapier-platform-core</code></a> is what allows your app to interact with Zapier. It holds the <code>z</code> object and app tester code. Your app depends on a specific version of <code>zapier-platform-core</code> in the <code>package.json</code> file. It&apos;s installed via <code>npm install</code> along with the rest of your app&apos;s dependencies.</p>
 </li>
-<li><p><a href="https://github.com/zapier/zapier-platform-schema"><code>zapier-platform-schema</code></a>: This is a separate package for maintainability purposes. It&apos;s a dependency installed automatically by <code>zapier-platform-core</code>. It&apos;s basically the package that enforces app schemas to match what Zapier has in the backend.</p>
+<li><p><a href="https://github.com/zapier/zapier-platform-schema"><code>zapier-platform-schema</code></a> enforces app structure behind the scenes. It&apos;s a dependency of <code>core</code>, so it will be installed automatically.</p>
 </li>
 </ul>
     </div>
@@ -4153,7 +4174,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h3 id="upgrading-zapier-platform-cli">Upgrading Zapier Platform CLI</h3>
+      <h3 id="updating">Updating</h3>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4162,61 +4183,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Check your version with <code>$ zapier --version</code> and update with <code>$ npm -g update zapier-platform-cli</code>.</p><p>You can also <a href="https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md">look at the Changelog</a> to understand what changed between versions.</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h4 id="when-to-update-cli">When to Update CLI</h4>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You should keep your <code>zapier-platform-cli</code> global package up-to-date to get the latest features and bug fixes for interacting with your app, but it&apos;s not mandatory. You should be able to use any publicly available <code>zapier-platform-cli</code> version.</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h3 id="upgrading-zapier-platform-core">Upgrading Zapier Platform Core</h3>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Open your app&apos;s <code>package.json</code> file and update the number for the <code>zapier-platform-core</code> entry to what the latest public version is. You can see it on the right side of the <a href="https://www.npmjs.com/package/zapier-platform-core">NPM registry page</a>. After that you should be able to run <code>npm update</code> and get the latest goodies!</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h4 id="when-to-update-core">When To Update Core</h4>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You should keep your <code>zapier-platform-core</code> package up-to-date to get the latest features and bug fixes for your app when interacting with Zapier, but it&apos;s not mandatory. You should be able to use any publicly available <code>zapier-platform-core</code> version.</p><p>While not always required, it&apos;s also recommended you use the same <code>zapier-platform-cli</code> global package as the app&apos;s <code>zapier-platform-core</code> one, to ensure maximum compatibility.</p>
+      <p>The Zapier platform and its tools are under active development While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforseen circumstances, all released platform versions will continue to work for the forseeable future. While you never <em>have</em> to upgrade your app&apos;s platform version, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md">changelog</a> to see what new features and bux fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <code>5.0.0</code>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://github.com/zapier/zapier-platform-core/releases">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4234,7 +4201,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This section is only relevant if you&apos;re editing the <code>zapier-platform-cli</code> package</p>
+      <p>This section is only relevant if you&apos;re editing the <code>zapier-platform-cli</code> package itself.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4300,7 +4267,7 @@ curl https://raw.githubusercontent.com/zapier/zapier-platform-cli/master/goodies
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You can get help by either emailing partners@zapier.com or by joining our Slack channel <a href="https://zapier-platform-slack.herokuapp.com">https://zapier-platform-slack.herokuapp.com</a>.</p>
+      <p>You can get help by either emailing <a href="mailto:partners@zapier.com">partners@zapier.com</a> or by joining our Slack channel <a href="https://zapier-platform-slack.herokuapp.com">https://zapier-platform-slack.herokuapp.com</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,7 +2261,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.3.0",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -5698,7 +5698,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -6347,16 +6347,16 @@
       }
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.3.0"
+        "semver": "5.5.0"
       }
     },
     "set-getter": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier": "1.9.1",
     "read": "1.0.7",
     "readable-stream": "2.2.2",
-    "semver": "5.3.0",
+    "semver": "5.5.0",
     "string-length": "1.0.1",
     "strip-comments": "0.4.4",
     "tar-stream": "1.5.2",

--- a/src/bin/docs.js
+++ b/src/bin/docs.js
@@ -13,7 +13,7 @@ const commands = require('../commands');
 
 const block = str => '> ' + str.split('\n').join('\n> ');
 
-const LAMBDA_VERSION = require('../constants').LAMBDA_VERSION;
+const { LAMBDA_VERSION, PACKAGE_VERSION } = require('../constants');
 
 // Takes all the cmd.docs and puts them into a big md file.
 const generateCliMarkdown = () => {
@@ -72,6 +72,10 @@ const fillLambdaVersion = line => {
   return line.replace(/LAMBDA_VERSION/g, LAMBDA_VERSION);
 };
 
+const fillPackageVersion = line => {
+  return line.replace(/PACKAGE_VERSION/g, PACKAGE_VERSION);
+};
+
 // Inserts code snippets from README-source.md into README.md
 const buildReadme = () => {
   const readmeSrc = path.resolve(__dirname, '../../README-source.md');
@@ -81,6 +85,7 @@ const buildReadme = () => {
   const newLines = lines
     .map(maybeInsertSnippet)
     .map(fillLambdaVersion)
+    .map(fillPackageVersion)
     .join('\n');
   const tocInstered = toc.insert(newLines);
   fs.writeFileSync(

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -4,8 +4,6 @@ const _ = require('lodash');
 const constants = require('../constants');
 const utils = require('../utils');
 const validate = require('./validate');
-const updateNotifier = require('update-notifier');
-const path = require('path');
 
 const test = context => {
   const extraEnv = {
@@ -55,21 +53,6 @@ const test = context => {
             context.line(stdout);
           }
         });
-    })
-    .then(() => {
-      // find a package.json for the app and notify on the core dep
-      // `zapier test` won't run if package.json isn't there, so if we get to here we're good
-      const requiredVersion = _.get(
-        require(path.resolve('./package.json')),
-        `dependencies.${constants.PLATFORM_PACKAGE}`
-      );
-
-      if (requiredVersion) {
-        updateNotifier({
-          pkg: { name: constants.PLATFORM_PACKAGE, version: requiredVersion },
-          updateCheckInterval: constants.UPDATE_NOTIFICATION_INTERVAL
-        }).notify({ isGlobal: false });
-      }
     });
 };
 test.argsSpec = [];

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -5,6 +5,7 @@ const constants = require('../constants');
 const utils = require('../utils');
 const validate = require('./validate');
 const updateNotifier = require('update-notifier');
+const path = require('path');
 
 const test = context => {
   const extraEnv = {
@@ -58,19 +59,17 @@ const test = context => {
     .then(() => {
       // find a package.json for the app and notify on the core dep
       // `zapier test` won't run if package.json isn't there, so if we get to here we're good
-      return utils.readFile('package.json').then(buf => {
-        const pk = JSON.parse(buf.toString());
-        const reliedVersion = _.get(
-          pk,
-          `dependencies.${constants.PLATFORM_PACKAGE}`
-        );
-        if (reliedVersion) {
-          updateNotifier({
-            pkg: { name: constants.PLATFORM_PACKAGE, version: reliedVersion },
-            updateCheckInterval: constants.UPDATE_NOTIFICATION_INTERVAL
-          }).notify({ isGlobal: false });
-        }
-      });
+      const requiredVersion = _.get(
+        require(path.resolve('./package.json')),
+        `dependencies.${constants.PLATFORM_PACKAGE}`
+      );
+
+      if (requiredVersion) {
+        updateNotifier({
+          pkg: { name: constants.PLATFORM_PACKAGE, version: requiredVersion },
+          updateCheckInterval: constants.UPDATE_NOTIFICATION_INTERVAL
+        }).notify({ isGlobal: false });
+      }
     });
 };
 test.argsSpec = [];

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,6 +24,7 @@ const nodeVersion = semver.Comparator(
 const LAMBDA_VERSION = `v${nodeVersion}`;
 const AUTH_KEY = 'deployKey';
 const PACKAGE_VERSION = require('../package.json').version;
+const UPDATE_NOTIFICATION_INTERVAL = 1000 * 60 * 60 * 24 * 7; // one week
 
 const ART = `\
                 zzzzzzzz
@@ -61,5 +62,6 @@ module.exports = {
   LAMBDA_VERSION,
   PACKAGE_VERSION,
   PLATFORM_PACKAGE,
-  STARTER_REPO
+  STARTER_REPO,
+  UPDATE_NOTIFICATION_INTERVAL
 };

--- a/src/entry.js
+++ b/src/entry.js
@@ -46,17 +46,10 @@ module.exports = argv => {
     process.exit(1);
   }
 
-  const notifier = updateNotifier({ pkg: require('../package.json') });
-
-  if (notifier.update) {
-    notifier.notify({
-      message: `Update available ${colors.grey(
-        notifier.update.current
-      )} → ${colors.green(notifier.update.latest)}\nRun ${colors.cyan(
-        'npm i -g zapier-platform-cli'
-      )} to update, and then ${colors.blue('re-test your integration')}.`
-    });
-  }
+  updateNotifier({
+    pkg: require('../package.json'),
+    updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // one week
+  }).notify();
 
   if (DEBUG) {
     console.log('running in:', process.cwd());

--- a/src/entry.js
+++ b/src/entry.js
@@ -50,10 +50,18 @@ module.exports = argv => {
     process.exit(1);
   }
 
-  updateNotifier({
-    pkg: require('../package.json'),
+  const pkg = require('../package.json');
+  const notifier = updateNotifier({
+    pkg: pkg,
     updateCheckInterval: UPDATE_NOTIFICATION_INTERVAL
-  }).notify();
+  });
+  if (notifier.update && notifier.update.latest !== pkg.version) {
+    notifier.notify({
+      message: `Update available ${pkg.version} → ${colors.green(
+        notifier.update.latest
+      )}\nRun ${colors.cyan('npm i -g ' + pkg.name)} to update`
+    });
+  }
 
   if (DEBUG) {
     console.log('running in:', process.cwd());

--- a/src/entry.js
+++ b/src/entry.js
@@ -78,12 +78,7 @@ module.exports = argv => {
   const context = utils.createContext({ command, args, argOpts });
 
   if (command === 'help' && (argOpts.version || argOpts.v)) {
-    context.line(
-      [
-        `zapier-platform-cli/${require('../package.json').version}`,
-        `node/${process.version}`
-      ].join('\n')
-    );
+    utils.printVersionInfo(context);
     return;
   }
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,7 +5,11 @@ const _ = require('lodash');
 const colors = require('colors/safe');
 const updateNotifier = require('update-notifier');
 
-const { DEBUG, LAMBDA_VERSION } = require('./constants');
+const {
+  DEBUG,
+  LAMBDA_VERSION,
+  UPDATE_NOTIFICATION_INTERVAL
+} = require('./constants');
 const commands = require('./commands');
 const utils = require('./utils');
 const leven = require('leven');
@@ -48,7 +52,7 @@ module.exports = argv => {
 
   updateNotifier({
     pkg: require('../package.json'),
-    updateCheckInterval: 1000 * 60 * 60 * 24 * 7 // one week
+    updateCheckInterval: UPDATE_NOTIFICATION_INTERVAL
   }).notify();
 
   if (DEBUG) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -274,18 +274,8 @@ const upload = (zipPath, appDir) => {
         }
       });
     })
-    .then(appVersion => {
+    .then(() => {
       printDone();
-
-      if (semver.lt(appVersion.platform_version, appVersion.core_npm_version)) {
-        console.log(
-          `\n**NOTE:** Your app is using zapier-platform-core@${
-            appVersion.platform_version
-          }, and there's a new version: ${
-            appVersion.core_npm_version
-          }. Please consider updating it: https://zapier.github.io/zapier-platform-cli/#upgrading-zapier-platform-cli-or-zapier-platform-core`
-        );
-      }
     });
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -9,7 +9,6 @@ const fs = require('fs');
 const AdmZip = require('adm-zip');
 const fetch = require('node-fetch');
 const path = require('path');
-const semver = require('semver');
 
 const { writeFile, readFile } = require('./files');
 

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -274,7 +274,7 @@ const build = (zipPath, wdir) => {
       updateCheckInterval: constants.UPDATE_NOTIFICATION_INTERVAL
     });
 
-    if (notifier.update) {
+    if (notifier.update && notifier.update.latest !== requiredVersion) {
       notifier.notify({
         message: `There's a newer version of ${colors.cyan(
           constants.PLATFORM_PACKAGE

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -271,7 +271,7 @@ const build = (zipPath, wdir) => {
   if (requiredVersion) {
     const notifier = updateNotifier({
       pkg: { name: constants.PLATFORM_PACKAGE, version: requiredVersion },
-      updateCheckInterval: 1 // constants.UPDATE_NOTIFICATION_INTERVAL
+      updateCheckInterval: constants.UPDATE_NOTIFICATION_INTERVAL
     });
 
     if (notifier.update) {

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -9,6 +9,8 @@ const archiver = require('archiver');
 const fs = require('fs');
 const fse = require('fs-extra');
 const klaw = require('klaw');
+const updateNotifier = require('update-notifier');
+const colors = require('colors/safe');
 
 const eslint = require('eslint');
 
@@ -258,6 +260,32 @@ const build = (zipPath, wdir) => {
     osTmpDir,
     'zapier-' + crypto.randomBytes(4).toString('hex')
   );
+
+  // find a package.json for the app and notify on the core dep
+  // `build` won't run if package.json isn't there, so if we get to here we're good
+  const requiredVersion = _.get(
+    require(path.resolve('./package.json')),
+    `dependencies.${constants.PLATFORM_PACKAGE}`
+  );
+
+  if (requiredVersion) {
+    const notifier = updateNotifier({
+      pkg: { name: constants.PLATFORM_PACKAGE, version: requiredVersion },
+      updateCheckInterval: 1 // constants.UPDATE_NOTIFICATION_INTERVAL
+    });
+
+    if (notifier.update) {
+      notifier.notify({
+        message: `There's a newer version of ${colors.cyan(
+          constants.PLATFORM_PACKAGE
+        )} available.\nConsider updating the dependency in your\n${colors.cyan(
+          'package.json'
+        )} (${colors.grey(notifier.update.current)} → ${colors.green(
+          notifier.update.latest
+        )}) and then running ${colors.red('zapier test')}.`
+      });
+    }
+  }
 
   return ensureDir(tmpDir)
     .then(() => ensureDir(constants.BUILD_DIR))

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -161,14 +161,16 @@ const printVersionInfo = context => {
 
   if (fileExistsSync(path.resolve('./package.json'))) {
     // might be a caret, have to coerce for later comparison
-    const requiredVersion = semver.coerce(
-      _.get(
-        require(path.resolve('./package.json')),
-        `dependencies.${PLATFORM_PACKAGE}`,
-        {}
-      )
+    //
+    let requiredVersion = _.get(
+      require(path.resolve('./package.json')),
+      `dependencies.${PLATFORM_PACKAGE}`,
+      {}
     ).version;
     if (requiredVersion) {
+      // might be a caret, have to coerce for later comparison
+      requiredVersion = semver.coerce(requiredVersion);
+
       // the single version their package.json requires
       versions.splice(1, 0, `zapier-platform-core/${requiredVersion}`);
 

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -162,12 +162,11 @@ const printVersionInfo = context => {
   if (fileExistsSync(path.resolve('./package.json'))) {
     let requiredVersion = _.get(
       require(path.resolve('./package.json')),
-      `dependencies.${PLATFORM_PACKAGE}`,
-      {}
-    ).version;
+      `dependencies.${PLATFORM_PACKAGE}`
+    );
     if (requiredVersion) {
       // might be a caret, have to coerce for later comparison
-      requiredVersion = semver.coerce(requiredVersion);
+      requiredVersion = semver.coerce(requiredVersion).version;
 
       // the single version their package.json requires
       versions.splice(1, 0, `zapier-platform-core/${requiredVersion}`);

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -172,6 +172,20 @@ const printVersionInfo = context => {
       // the single version their package.json requires
       versions.splice(1, 0, `zapier-platform-core/${requiredVersion}`);
 
+      if (requiredVersion !== PACKAGE_VERSION) {
+        versions.push(
+          `${colors.yellow('\nWarning!')} "CLI" (${colors.green(
+            PACKAGE_VERSION
+          )}) and "core" (${colors.green(
+            requiredVersion
+          )}) versions are out of sync. This is probably fine, but if you're epxeriencing issues, update the ${colors.cyan(
+            PLATFORM_PACKAGE
+          )} dependency in your ${colors.cyan(
+            'package.json'
+          )} to ${colors.green(PACKAGE_VERSION)}.`
+        );
+      }
+
       if (
         fileExistsSync(
           path.resolve(`./node_modules/${PLATFORM_PACKAGE}/package.json`)

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -160,8 +160,6 @@ const printVersionInfo = context => {
   ];
 
   if (fileExistsSync(path.resolve('./package.json'))) {
-    // might be a caret, have to coerce for later comparison
-    //
     let requiredVersion = _.get(
       require(path.resolve('./package.json')),
       `dependencies.${PLATFORM_PACKAGE}`,

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -13,6 +13,8 @@ const {
   LAMBDA_VERSION
 } = require('../constants');
 
+const { fileExistsSync } = require('./files');
+
 const camelCase = str => _.capitalize(_.camelCase(str));
 const snakeCase = str => _.snakeCase(str);
 
@@ -151,6 +153,51 @@ const entryPoint = dir => {
   return fse.realpathSync(path.resolve(dir, packageJson.main));
 };
 
+const printVersionInfo = context => {
+  const versions = [
+    `zapier-platform-cli/${PACKAGE_VERSION}`,
+    `node/${process.version}`
+  ];
+
+  if (fileExistsSync(path.resolve('./package.json'))) {
+    // might be a caret, have to coerce for later comparison
+    const requiredVersion = semver.coerce(
+      _.get(
+        require(path.resolve('./package.json')),
+        `dependencies.${PLATFORM_PACKAGE}`,
+        {}
+      )
+    ).version;
+    if (requiredVersion) {
+      // the single version their package.json requires
+      versions.splice(1, 0, `zapier-platform-core/${requiredVersion}`);
+
+      if (
+        fileExistsSync(
+          path.resolve(`./node_modules/${PLATFORM_PACKAGE}/package.json`)
+        )
+      ) {
+        // double check they have the right version installed
+        const installedPkgVersion = require(path.resolve(
+          `./node_modules/${PLATFORM_PACKAGE}/package.json`
+        )).version;
+
+        if (requiredVersion !== installedPkgVersion) {
+          versions.push(
+            `${colors.yellow('\nWarning!')} Required version (${colors.green(
+              requiredVersion
+            )}) and installed version (${colors.green(
+              installedPkgVersion
+            )}) are out of sync. Run ${colors.cyan('`npm install`')} to fix.\n`
+          );
+        }
+      }
+    }
+  }
+
+  context.line(versions.join('\n'));
+};
+
 module.exports = {
   camelCase,
   entryPoint,
@@ -158,6 +205,7 @@ module.exports = {
   isValidNodeVersion,
   isWindows,
   npmInstall,
+  printVersionInfo,
   promiseDoWhile,
   promiseForever,
   runCommand,


### PR DESCRIPTION
Per our conversation, pull out some of the reminding about updating version. 

I pulled the custom update method because the user needs to update both CLI and the core dep in each of their apps, which gets a little wordy for an update message. Maybe we should add a section to the doc about what you need to update and when?