### PR TITLE
Fix issue where calls to utils.printData hangs

### DIFF
--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -9,18 +9,62 @@ describe('utils', () => {
     global._babelPolyfill.should.eql(true);
   });
 
-  // For some reason, Travis dies on this one
-  it.skip('should print a nice little table', () => {
-    const table = utils.makeTable(
-      [{ id: 123, title: 'hello' }, { id: 456, title: 'world' }],
-      [['ID', 'id'], ['Title', 'title'], ['Missing', 'missing']]
-    );
-    table.indexOf('ID').should.be.above(0);
-    table.indexOf('Title').should.be.above(0);
-    table.indexOf('Missing').should.be.above(0);
-    table.indexOf('123').should.be.above(0);
-    table.indexOf('hello').should.be.above(0);
-    table.indexOf('456').should.be.above(0);
-    table.indexOf('world').should.be.above(0);
+  it('should print a nice little table', () => {
+    const originalWidth = process.stdout.columns;
+    try {
+      process.stdout.columns = 50;
+      const table = utils.makeTable(
+        [{ id: 123, title: 'hello' }, { id: 456, title: 'world' }],
+        [['ID', 'id'], ['Title', 'title'], ['Missing', 'missing']]
+      );
+
+      // Verify presence
+      table.indexOf('ID').should.be.above(-1);
+      table.indexOf('Title').should.be.above(-1);
+      table.indexOf('Missing').should.be.above(-1);
+      table.indexOf('123').should.be.above(-1);
+      table.indexOf('hello').should.be.above(-1);
+      table.indexOf('456').should.be.above(-1);
+      table.indexOf('world').should.be.above(-1);
+
+      // Verify order
+      table.indexOf('ID').should.be.below(table.indexOf('Title'));
+      table.indexOf('Title').should.be.below(table.indexOf('Missing'));
+      table.indexOf('Missing').should.be.below(table.indexOf('123'));
+      table.indexOf('123').should.be.below(table.indexOf('hello'));
+      table.indexOf('hello').should.be.below(table.indexOf('456'));
+      table.indexOf('456').should.be.below(table.indexOf('world'));
+    } finally {
+      process.stdout.columns = originalWidth;
+    }
+  });
+
+  it('should print plain when the canvas is too small', () => {
+    const originalWidth = process.stdout.columns;
+    try {
+      process.stdout.columns = 15;
+      const table = utils.makeTable(
+        [{ id: 123, title: 'hello' }, { id: 456, title: 'world' }],
+        [['ID', 'id'], ['Title', 'title'], ['Missing', 'missing']]
+      );
+
+      // Verify presence
+      table.indexOf('ID').should.be.above(-1);
+      table.indexOf('Title').should.be.above(-1);
+      table.indexOf('Missing').should.be.above(-1);
+      table.indexOf('123').should.be.above(-1);
+      table.indexOf('hello').should.be.above(-1);
+      table.indexOf('456').should.be.above(-1);
+      table.indexOf('world').should.be.above(-1);
+
+      // Verify order
+      table.indexOf('ID').should.be.below(table.indexOf('123'));
+      table.indexOf('123').should.be.below(table.indexOf('Title'));
+      table.indexOf('Title').should.be.below(table.indexOf('hello'));
+      table.indexOf('hello').should.be.below(table.indexOf('456'));
+      table.indexOf('456').should.be.below(table.indexOf('world'));
+    } finally {
+      process.stdout.columns = originalWidth;
+    }
   });
 });

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -98,6 +98,9 @@ const makeRowBasedTable = (rows, columnDefs, { includeIndex = true } = {}) => {
     1
   );
   const widthForValue = process.stdout.columns - maxLabelLength - 15; // The last bit accounts for some padding and borders
+  if (widthForValue < 1) {
+    return makePlain(rows, columnDefs); // There's not enough space to display the table
+  }
 
   rows.forEach((row, index) => {
     if (includeIndex) {


### PR DESCRIPTION
Resolves #279 

When calls to `utils.printData` were made on a headless machine (such as a CI) or a "skinny" terminal (with a column width less than a certain amount of columns - 15 would always do it), the call would get stuck in a while loop. To make a long story short, this loop was lopping off text based on how many columns we had calculated were available for use. But when the calculated width was non-positive, the text-lopping never ended because we were saying ~'drop the first -6 characters of "example"'.

Now, when the calculated width is non-positive, the entire while-loop is avoided by directly returning the `makePlain` call.

As a bonus, this should fix an old test that was marked skipped. :)