### PR TITLE
Use update-notifier's default message

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -56,11 +56,7 @@ module.exports = argv => {
     updateCheckInterval: UPDATE_NOTIFICATION_INTERVAL
   });
   if (notifier.update && notifier.update.latest !== pkg.version) {
-    notifier.notify({
-      message: `Update available ${pkg.version} → ${colors.green(
-        notifier.update.latest
-      )}\nRun ${colors.cyan('npm i -g ' + pkg.name)} to update`
-    });
+    notifier.notify({ isGlobal: true });
   }
 
   if (DEBUG) {


### PR DESCRIPTION
Per our [discussion](https://github.com/zapier/zapier-platform-cli/commit/9e45d10389b7b7d7c75d472de8ff8abe5953fe28#r28319291), this PR changes to use update-notifier's default message to prompt users for a package update. Since we always want to put a `-g` option in the `npm install` command as a part of the message, we need to pass `isGlobal: true` to `notifier.notify()`. Otherwise, `.notify()` detects if the current installation is global and add the `-g` option accordingly.