### PR TITLE
Print npm stderr if `npm install` fails

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -48,9 +48,9 @@ const test = context => {
       context.line('Running test suite.');
       return utils
         .runCommand('npm', commands, { stdio: 'inherit', env })
-        .then(stdout => {
-          if (stdout) {
-            context.line(stdout);
+        .then(output => {
+          if (output.stdout) {
+            context.line(output.stdout);
           }
         });
     });

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -309,6 +309,20 @@ const build = (zipPath, wdir) => {
       printStarting('Installing project dependencies');
       return runCommand('npm', ['install', '--production'], { cwd: tmpDir });
     })
+    .then(output => {
+      // `npm install` may fail silently without returning a non-zero exit code, need to check further here
+      const corePath = path.join(
+        tmpDir,
+        'node_modules',
+        constants.PLATFORM_PACKAGE
+      );
+      if (!fs.exists(corePath)) {
+        throw new Error(
+          'Could not install dependencies properly. Error log:\n' +
+            output.stderr
+        );
+      }
+    })
     .then(() => {
       printDone();
       printStarting('Applying entry point file');

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -316,7 +316,7 @@ const build = (zipPath, wdir) => {
         'node_modules',
         constants.PLATFORM_PACKAGE
       );
-      if (!fs.exists(corePath)) {
+      if (!fs.existsSync(corePath)) {
         throw new Error(
           'Could not install dependencies properly. Error log:\n' +
             output.stderr

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -43,9 +43,10 @@ const runCommand = (command, args, options) => {
     let stdout = '';
     if (result.stdout) {
       result.stdout.on('data', data => {
-        stdout += data.toString();
+        const str = data.toString();
+        stdout += str;
         if (global.argOpts.debug) {
-          console.log(colors.green(stdout));
+          process.stdout.write(colors.green(str));
         }
       });
     }
@@ -53,9 +54,10 @@ const runCommand = (command, args, options) => {
     let stderr = '';
     if (result.stderr) {
       result.stderr.on('data', data => {
-        stderr += data.toString();
+        const str = data.toString();
+        stderr += str;
         if (global.argOpts.debug) {
-          console.log(colors.red(stdout));
+          process.stderr.write(colors.red(str));
         }
       });
     }
@@ -66,7 +68,7 @@ const runCommand = (command, args, options) => {
       if (code !== 0) {
         reject(new Error(stderr));
       }
-      resolve(stdout);
+      resolve({ stdout, stderr });
     });
   });
 };


### PR DESCRIPTION
Fixes #82 and zapier/zapier#16579.

Our current code in `zapier build ` assumes if `npm install` returns 0, everything is good. But `npm install` may fail without returning a non-zero exit code. For example, try `npm install` when the `name` in `package.json` has a space character. In this case, `npm` prints the error to stderr, but exits with 0 as if it was successful.

So what we should do instead, is to check further if `APP_DIR/node_modules/zapier-platform-core` exists to make sure `npm install` is really successful before moving on to the next step.

With this PR, now if you `zapier build` an app with a space in thier `name` in `package.json`, we'll show the stderr from `npm`:

```
$ zapier build
Building project.

  Copying project to temp directory ⠃ done!
  Installing project dependencies ⠆

Error! Could not install dependencies properly. Error log:
npm WARN Invalid name: "my app"
npm WARN zapier-d1da7977 No description
npm WARN zapier-d1da7977 No repository field.
npm WARN zapier-d1da7977 No README data
npm WARN zapier-d1da7977 No license field.


(Use --debug flag and run this command again to get more details.)
```