### PR TITLE
Adding the option to show bundle logs

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -915,7 +915,7 @@ See a full example with dehydration/hydration wired in correctly:
 
 There are two types of logs for a Zapier app, console logs and HTTP logs. The console logs are created by your app through the use of the `z.console.log` method ([see below for details](#console-logging)). The HTTP logs are created automatically by Zapier whenever your app makes HTTP requests (as long as you use `z.request([url], options)` or shorthand request objects).
 
-To view the logs for your application, use the `zapier logs` command. There are two types of logs, `http` (logged automatically by Zapier on HTTP requests) and `console` (manual logs via `z.console.log()` statements).
+To view the logs for your application, use the `zapier logs` command. There are three types of logs, `http` (logged automatically by Zapier on HTTP requests), `bundle` (logged automatically on every method execution), and `console` (manual logs via `z.console.log()` statements).
 
 For advanced logging options including only displaying the logs for a certain user or app version, look at the help for the logs command:
 
@@ -939,6 +939,14 @@ To see your `z.console.log` logs, do:
 
 ```bash
 zapier logs --type=console
+```
+
+### Viewing Bundle Logs
+
+To see the bundle logs, do:
+
+```bash
+zapier logs --type=bundle
 ```
 
 ### HTTP Logging

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 - [Logging](#logging)
   * [Console Logging](#console-logging)
   * [Viewing Console Logs](#viewing-console-logs)
+  * [Viewing Bundle Logs](#viewing-bundle-logs)
   * [HTTP Logging](#http-logging)
   * [Viewing HTTP Logs](#viewing-http-logs)
 - [Error Handling](#error-handling)
@@ -1721,7 +1722,7 @@ module.exports = App;
 
 There are two types of logs for a Zapier app, console logs and HTTP logs. The console logs are created by your app through the use of the `z.console.log` method ([see below for details](#console-logging)). The HTTP logs are created automatically by Zapier whenever your app makes HTTP requests (as long as you use `z.request([url], options)` or shorthand request objects).
 
-To view the logs for your application, use the `zapier logs` command. There are two types of logs, `http` (logged automatically by Zapier on HTTP requests) and `console` (manual logs via `z.console.log()` statements).
+To view the logs for your application, use the `zapier logs` command. There are three types of logs, `http` (logged automatically by Zapier on HTTP requests), `bundle` (logged automatically on every method execution), and `console` (manual logs via `z.console.log()` statements).
 
 For advanced logging options including only displaying the logs for a certain user or app version, look at the help for the logs command:
 
@@ -1745,6 +1746,14 @@ To see your `z.console.log` logs, do:
 
 ```bash
 zapier logs --type=console
+```
+
+### Viewing Bundle Logs
+
+To see the bundle logs, do:
+
+```bash
+zapier logs --type=bundle
 ```
 
 ### HTTP Logging

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -946,7 +946,7 @@ All personal keys deactivated - now try `zapier login` to login again.
 </blockquote><p><strong>Arguments</strong></p><ul>
 <li><code>--version=value</code> -- <em>optional</em>, display only this version&apos;s logs (default is all versions)</li>
 <li><code>--status={any,success,error}</code> -- <em>optional</em>, display only success logs (status code &lt; 400 / info) or error (status code &gt; 400 / tracebacks). Default is <code>any</code></li>
-<li><code>--type={console,http}</code> -- <em>optional</em>, display only console or http logs. Default is <code>console</code></li>
+<li><code>--type={console,bundle,http}</code> -- <em>optional</em>, display only console, bundle, or http logs. Default is <code>console</code></li>
 <li><code>--detailed</code> -- <em>optional</em>, show detailed logs (like request/response body and headers)</li>
 <li><a href="mailto:`--user=user@example.com">`--user=user@example.com</a><code>-- _optional_, display only this user&apos;s logs. Default is</code>me`</li>
 <li><code>--limit=50</code> -- <em>optional</em>, control the maximum result size. Default is <code>50</code></li>
@@ -979,37 +979,6 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 <span class="hljs-comment"># &#x2502;     Step        &#x2502; 99c16565-1547-4b16-bcb5-45189d9d8afa &#x2502;</span>
 <span class="hljs-comment"># &#x2502;     Timestamp   &#x2502; 2016-01-01T23:04:36-05:00            &#x2502;</span>
 <span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
-
-$ zapier logs --<span class="hljs-built_in">type</span>=http --detailed --format=plain
-<span class="hljs-comment"># The logs of your app &quot;Example&quot; listed below.</span>
-<span class="hljs-comment">#</span>
-<span class="hljs-comment"># == Status</span>
-<span class="hljs-comment"># 200</span>
-<span class="hljs-comment"># == URL</span>
-<span class="hljs-comment"># http://httpbin.org/get</span>
-<span class="hljs-comment"># == Querystring</span>
-<span class="hljs-comment"># hello=world</span>
-<span class="hljs-comment"># == Version</span>
-<span class="hljs-comment"># 1.0.0</span>
-<span class="hljs-comment"># == Step</span>
-<span class="hljs-comment"># 99c16565-1547-4b16-bcb5-45189d9d8afa</span>
-<span class="hljs-comment"># == Timestamp</span>
-<span class="hljs-comment"># 2016-08-03T23:04:36-05:00</span>
-<span class="hljs-comment"># == Request Body</span>
-<span class="hljs-comment"># == Response Body</span>
-<span class="hljs-comment"># {</span>
-<span class="hljs-comment">#   &quot;args&quot;: {</span>
-<span class="hljs-comment">#     &quot;hello&quot;: &quot;world&quot;</span>
-<span class="hljs-comment">#   },</span>
-<span class="hljs-comment">#   &quot;headers&quot;: {</span>
-<span class="hljs-comment">#     &quot;Accept&quot;: &quot;*/*&quot;,</span>
-<span class="hljs-comment">#     &quot;Accept-Encoding&quot;: &quot;gzip,deflate&quot;,</span>
-<span class="hljs-comment">#     &quot;Host&quot;: &quot;httpbin.org&quot;,</span>
-<span class="hljs-comment">#     &quot;User-Agent&quot;: &quot;Zapier&quot;</span>
-<span class="hljs-comment">#   },</span>
-<span class="hljs-comment">#   &quot;origin&quot;: &quot;123.123.123.123&quot;,</span>
-<span class="hljs-comment">#   &quot;url&quot;: &quot;http://httpbin.org/get?hello=world&quot;</span>
-<span class="hljs-comment"># }</span>
 </code></pre>
     </div>
   </div>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -597,7 +597,7 @@ Get the logs that are automatically collected during the running of your app. Ei
 
 * `--version=value` -- _optional_, display only this version's logs (default is all versions)
 * `--status={any,success,error}` -- _optional_, display only success logs (status code < 400 / info) or error (status code > 400 / tracebacks). Default is `any`
-* `--type={console,http}` -- _optional_, display only console or http logs. Default is `console`
+* `--type={console,bundle,http}` -- _optional_, display only console, bundle, or http logs. Default is `console`
 * `--detailed` -- _optional_, show detailed logs (like request/response body and headers)
 * `--user=user@example.com` -- _optional_, display only this user's logs. Default is `me`
 * `--limit=50` -- _optional_, control the maximum result size. Default is `50`
@@ -629,37 +629,6 @@ $ zapier logs --type=http
 # │     Step        │ 99c16565-1547-4b16-bcb5-45189d9d8afa │
 # │     Timestamp   │ 2016-01-01T23:04:36-05:00            │
 # └─────────────────┴──────────────────────────────────────┘
-
-$ zapier logs --type=http --detailed --format=plain
-# The logs of your app "Example" listed below.
-#
-# == Status
-# 200
-# == URL
-# http://httpbin.org/get
-# == Querystring
-# hello=world
-# == Version
-# 1.0.0
-# == Step
-# 99c16565-1547-4b16-bcb5-45189d9d8afa
-# == Timestamp
-# 2016-08-03T23:04:36-05:00
-# == Request Body
-# == Response Body
-# {
-#   "args": {
-#     "hello": "world"
-#   },
-#   "headers": {
-#     "Accept": "*/*",
-#     "Accept-Encoding": "gzip,deflate",
-#     "Host": "httpbin.org",
-#     "User-Agent": "Zapier"
-#   },
-#   "origin": "123.123.123.123",
-#   "url": "http://httpbin.org/get?hello=world"
-# }
 ```
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -326,6 +326,7 @@ a code {
 <li><a href="#logging">Logging</a><ul>
 <li><a href="#console-logging">Console Logging</a></li>
 <li><a href="#viewing-console-logs">Viewing Console Logs</a></li>
+<li><a href="#viewing-bundle-logs">Viewing Bundle Logs</a></li>
 <li><a href="#http-logging">HTTP Logging</a></li>
 <li><a href="#viewing-http-logs">Viewing HTTP Logs</a></li>
 </ul>
@@ -506,6 +507,7 @@ a code {
 <li><a href="#logging">Logging</a><ul>
 <li><a href="#console-logging">Console Logging</a></li>
 <li><a href="#viewing-console-logs">Viewing Console Logs</a></li>
+<li><a href="#viewing-bundle-logs">Viewing Bundle Logs</a></li>
 <li><a href="#http-logging">HTTP Logging</a></li>
 <li><a href="#viewing-http-logs">Viewing HTTP Logs</a></li>
 </ul>
@@ -3074,7 +3076,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>There are two types of logs for a Zapier app, console logs and HTTP logs. The console logs are created by your app through the use of the <code>z.console.log</code> method (<a href="#console-logging">see below for details</a>). The HTTP logs are created automatically by Zapier whenever your app makes HTTP requests (as long as you use <code>z.request([url], options)</code> or shorthand request objects).</p><p>To view the logs for your application, use the <code>zapier logs</code> command. There are two types of logs, <code>http</code> (logged automatically by Zapier on HTTP requests) and <code>console</code> (manual logs via <code>z.console.log()</code> statements).</p><p>For advanced logging options including only displaying the logs for a certain user or app version, look at the help for the logs command:</p>
+      <p>There are two types of logs for a Zapier app, console logs and HTTP logs. The console logs are created by your app through the use of the <code>z.console.log</code> method (<a href="#console-logging">see below for details</a>). The HTTP logs are created automatically by Zapier whenever your app makes HTTP requests (as long as you use <code>z.request([url], options)</code> or shorthand request objects).</p><p>To view the logs for your application, use the <code>zapier logs</code> command. There are three types of logs, <code>http</code> (logged automatically by Zapier on HTTP requests), <code>bundle</code> (logged automatically on every method execution), and <code>console</code> (manual logs via <code>z.console.log()</code> statements).</p><p>For advanced logging options including only displaying the logs for a certain user or app version, look at the help for the logs command:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier <span class="hljs-built_in">help</span> logs
@@ -3125,6 +3127,25 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier logs --<span class="hljs-built_in">type</span>=console
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="viewing-bundle-logs">Viewing Bundle Logs</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>To see the bundle logs, do:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-bash">zapier logs --<span class="hljs-built_in">type</span>=bundle
 </code></pre>
     </div>
   </div>

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -28,6 +28,15 @@ const logs = context => {
         columns.push(['Response Headers', 'response_headers']);
         columns.push(['Response Body', 'response_content']);
       }
+    } else if (type === 'bundle') {
+      columns = [
+        ['Log', 'message'],
+        ['Input', 'input'],
+        ['Output', 'output'],
+        ['Version', 'app_cli_version'],
+        // ['ID', 'id'],
+        ['Timestamp', 'timestamp']
+      ];
     } else {
       columns = [
         ['Log', 'full_message'],
@@ -69,8 +78,8 @@ logs.argOptsSpec = {
     default: 'any'
   },
   type: {
-    help: 'display only console or http logs',
-    choices: ['console', 'http'],
+    help: 'display only console, bundle, or http logs',
+    choices: ['console', 'bundle', 'http'],
     default: 'console'
   },
   detailed: {
@@ -121,37 +130,6 @@ $ zapier logs --type=http
 # │     Step        │ 99c16565-1547-4b16-bcb5-45189d9d8afa │
 # │     Timestamp   │ 2016-01-01T23:04:36-05:00            │
 # └─────────────────┴──────────────────────────────────────┘
-
-$ zapier logs --type=http --detailed --format=plain
-# The logs of your app "Example" listed below.
-#
-# == Status
-# 200
-# == URL
-# http://httpbin.org/get
-# == Querystring
-# hello=world
-# == Version
-# 1.0.0
-# == Step
-# 99c16565-1547-4b16-bcb5-45189d9d8afa
-# == Timestamp
-# 2016-08-03T23:04:36-05:00
-# == Request Body
-# == Response Body
-# {
-#   "args": {
-#     "hello": "world"
-#   },
-#   "headers": {
-#     "Accept": "*/*",
-#     "Accept-Encoding": "gzip,deflate",
-#     "Host": "httpbin.org",
-#     "User-Agent": "Zapier"
-#   },
-#   "origin": "123.123.123.123",
-#   "url": "http://httpbin.org/get?hello=world"
-# }
 ${'```'}
 `;
 


### PR DESCRIPTION
Also improved the `zapier help logs` to not show so many examples, because it pushed the helpful argument list to above the fold, which was annoying.

![](https://cdn.zapier.com/storage/photos/c68c529ef58cf7d19ea0de69e3e90b4f.png)

Closes [PDE-153](https://zapierorg.atlassian.net/secure/RapidBoard.jspa?rapidView=13&projectKey=PDE&modal=detail&selectedIssue=PDE-153) and depends on
https://github.com/zapier/zapier/pull/16608