### PR TITLE
Close getAccessToken function

### DIFF
--- a/scaffold/convert/oauth2.template.js
+++ b/scaffold/convert/oauth2.template.js
@@ -78,6 +78,7 @@ const getAccessToken = (z, bundle) => {
     };
     return legacyScriptingRunner.runEvent(postOAuth2TokenEvent, z, bundle);
   });
+};
 <% }
 
    if (withRefresh && hasPreOAuthRefreshScripting) { %>


### PR DESCRIPTION
Fixes:

```
SyntaxError: Unexpected token (61:1)
  59 |
  60 | module.exports = authentication;
> 61 |
     | ^
    at createError$1 (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/parser-babylon.js:1:112)
    at parse (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/parser-babylon.js:1:878)
    at Object.parse$1 [as parse] (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:5855:12)
    at formatWithCursor (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27628:22)
    at format (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27671:10)
    at Object.format (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27910:12)
    at js (/Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/lib/utils/convert.js:103:27)
    at /Users/fokkezb/.nvm/versions/node/v8.10.0/lib/node_modules/zapier-platform-cli/lib/utils/convert.js:111:16
    at <anonymous>

Error!
```

Which falls on `getAccessToken` not getting closed on this generated content:

```js
const { replaceVars } = require('./utils');
const testTrigger = require('./triggers/wbx_list_forms');

const getAccessToken = (z, bundle) => {
  const scripting = require('./scripting');
  const legacyScriptingRunner = require('zapier-platform-legacy-scripting-runner')(scripting);

  bundle._legacyUrl = 'https://api.webconnex.com/v1/oauth/apikey';
  bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);

  const responsePromise = z.request({
    method: 'POST',
    url: bundle._legacyUrl,
    body: {
      code: bundle.inputData.code,
      client_id: process.env.CLIENT_ID,
      client_secret: process.env.CLIENT_SECRET,
      redirect_uri: bundle.inputData.redirect_uri,
      grant_type: 'authorization_code',
    },
    headers: {
      'Content-Type': 'application/x-www-form-urlencoded',
    }
  });
  return responsePromise.then((response) => {
    // Do a post_oauthv2_token() from scripting.
    const postOAuth2TokenEvent = {
      name: 'auth.oauth2.token.post',
      response,
    };
    return legacyScriptingRunner.runEvent(postOAuth2TokenEvent, z, bundle);
  });

const authentication = {
  // TODO: just an example stub - you'll need to complete
  type: 'oauth2',
  test: testTrigger.operation.perform,
  oauth2Config: {
    authorizeUrl: {
      method: 'GET',
      url: 'https://manage.webconnex.com/oauth/authorize',
      params: {
        client_id: '{{process.env.CLIENT_ID}}',
        state: '{{bundle.inputData.state}}',
        redirect_uri: '{{bundle.inputData.redirect_uri}}',
        response_type: 'code'
      }
    },

    getAccessToken: getAccessToken,

    scope: '',

  },

  connectionLabel: ''

};

module.exports = authentication;
```