### PR TITLE
[WIP] Clarify the meaning of bundle.inputData and bundle.authData in connection label functions

### DIFF
--- a/snippets/digest-auth.js
+++ b/snippets/digest-auth.js
@@ -5,8 +5,9 @@ const authentication = {
     url: 'https://example.com/api/accounts/me.json'
   },
   connectionLabel: (z, bundle) => {
-    // Can also be a string, check basic auth above for an example
-    // bundle.inputData has whatever comes back from the .test function/request, assuming it returns a JSON object
+    // You may define the `connectionLabel` with a string instead of a function—take a look at the Basic Auth example above.
+    // bundle.inputData is an object containing the data returned by the .test function/request (assuming it returns an object).
+    // For example, in this function, `bundle.inputData` would be the data returned by `https://example.com/api/accounts/me.json`.
     return bundle.inputData.email;
   }
   // you can provide additional fields, but Zapier will provide `username`/`password` automatically


### PR DESCRIPTION
To Do: 

- [x] elaborate on what bundle.inputData means in a Digest Auth connectionLabel 
- [ ] add a note to the [Bundle Object](https://zapier.github.io/zapier-platform-cli/#bundle-object) section to clarify that `bundle.inputData` doesn't necessarily represent user-defined data in certain contexts (custom auth, possibly more)
- [ ] add an FAQ that explains Connection Labels in more detail as we don't discuss it outside of the code snippets. perhaps borrow from: https://zapier.com/developer/documentation/v2/appdevguide-auth/#connection-label