### PR TITLE
Convert: Escape sample field labels

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -201,7 +201,7 @@ const renderSampleField = (def, indent = 0) => {
   props.push(renderProp('type', quote(type)));
 
   if (def.label) {
-    props.push(renderProp('label', quote(def.label)));
+    props.push(renderProp('label', quote(escapeSpecialChars(def.label))));
   }
 
   props = props.map(s => ' '.repeat(indent + 2) + s);


### PR DESCRIPTION
Fixes:

```
SyntaxError: Unexpected token, expected "," (37:24)
  35 |         key: 'member_email',
  36 |         type: 'string',
> 37 |         label: 'Member's Email'
     |                        ^
  38 |       },
  39 |       {
  40 |         key: 'member_external_id',
    at createError$1 (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/parser-babylon.js:1:112)
    at parse (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/parser-babylon.js:1:878)
    at Object.parse$1 [as parse] (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:5855:12)
    at formatWithCursor (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27628:22)
    at format (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27671:10)
    at Object.format (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/node_modules/prettier/index.js:27910:12)
    at js (/Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/lib/utils/convert.js:102:27)
    at /Users/fokkezb/.nvm/versions/node/v8.11.1/lib/node_modules/zapier-platform-cli/lib/utils/convert.js:109:16
    at <anonymous>
```