### PR TITLE
Ask for promote when fully migrating a public app

### DIFF
--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -19,7 +19,7 @@ const migrate = (context, fromVersion, toVersion, optionalPercent = '100%') => {
   return utils
     .getLinkedApp()
     .then(app => {
-      let promoteFirst = false;
+      let answerPromise = false;
       if (
         optionalPercent === 100 &&
         app.public &&
@@ -39,15 +39,15 @@ const migrate = (context, fromVersion, toVersion, optionalPercent = '100%') => {
           if (!yes && !no) {
             throw new Error('That answer is not valid. Please try "y" or "n".');
           }
-          return yes;
+          return true;
         };
-        promoteFirst = utils.promiseDoWhile(action, stop);
+        answerPromise = utils.promiseDoWhile(action, stop);
       }
-      return Promise.all([app, promoteFirst]);
+      return Promise.all([app, answerPromise]);
     })
-    .then(([app, promoteFirst]) => {
+    .then(([app, answer]) => {
       let promotePromise = null;
-      if (promoteFirst) {
+      if (hasAccepted(answer)) {
         promotePromise = promote(context, toVersion, false);
       }
       return Promise.all([app, promotePromise]);

--- a/src/commands/promote.js
+++ b/src/commands/promote.js
@@ -9,7 +9,7 @@ const hasCancelled = answer =>
 const hasAccepted = answer =>
   answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
 
-const promote = (context, version) => {
+const promote = (context, version, printMigrateHint = true) => {
   if (!version) {
     context.line('Error: No deploment/version selected...\n');
     return Promise.resolve();
@@ -89,9 +89,11 @@ const promote = (context, version) => {
     .then(() => {
       utils.endSpinner();
       context.line('  Promotion successful!\n');
-      context.line(
-        'Optionally, run the `zapier migrate` command to move users to this version.'
-      );
+      if (printMigrateHint) {
+        context.line(
+          'Optionally, run the `zapier migrate` command to move users to this version.'
+        );
+      }
     })
     .catch(response => {
       // we probalby have a raw response, might have a thrown error

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -268,9 +268,31 @@ const getInput = (question, { secret = false } = {}) => {
   });
 };
 
+const hasAccepted = answer =>
+  answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+
+const hasRejected = answer =>
+  answer.toLowerCase() === 'n' || answer.toLowerCase() === 'no';
+
+const getYesNoInput = (question, showCtrlC = true) => {
+  let message = question + ' (y/n) ';
+  if (showCtrlC) {
+    message += '(Ctrl-C to cancel) ';
+  }
+  return getInput(message).then(answer => {
+    const yes = hasAccepted(answer);
+    const no = hasRejected(answer);
+    if (!yes && !no) {
+      throw new Error('That answer is not valid. Please try "y" or "n".');
+    }
+    return yes;
+  });
+};
+
 module.exports = {
   formatStyles,
   getInput,
+  getYesNoInput,
   makeRowBasedTable,
   makeTable,
   markdownLog,

--- a/src/utils/init.js
+++ b/src/utils/init.js
@@ -1,17 +1,18 @@
 const path = require('path');
 const tmp = require('tmp');
 
-const { startSpinner, endSpinner, getInput } = require('./display');
+const { startSpinner, endSpinner, getYesNoInput } = require('./display');
 const { isEmptyDir, copyDir, removeDir, ensureDir } = require('./files');
 
 const confirmNonEmptyDir = location => {
   if (location === '.') {
     return isEmptyDir(location).then(isEmpty => {
       if (!isEmpty) {
-        return getInput(
-          'Current directory not empty, continue anyway? (y/n) '
-        ).then(answer => {
-          if (!answer.match(/^y/i)) {
+        return getYesNoInput(
+          'Current directory not empty, continue anyway?',
+          false
+        ).then(yes => {
+          if (!yes) {
             /*eslint no-process-exit: 0 */
             process.exit(0);
           }

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -124,7 +124,7 @@ const npmInstall = appDir => {
 /*
   Promise do-while loop. Executes promise returned by action,
   passing result to stop function. Keeps running action until
-  stop returns falsey. Action is always run at least once.
+  stop returns truthy. Action is always run at least once.
  */
 const promiseDoWhile = (action, stop) => {
   const loop = () => action().then(result => (stop(result) ? result : loop()));


### PR DESCRIPTION
Addresses [PDE-160](https://zapierorg.atlassian.net/browse/PDE-160).

It makes little sense to migrate 100% without a promotion beforehand. This PR adjusts the behavior of `zapier migrate` so that when a dev does a 100% migration on a public app, we ask if the dev wants to promote that version first.

As for private apps, the 100% migration should automatically do an implicit promotion for the devs. It's already being implemented in the backend, so we don't need to handle that here.