### PR TITLE
src/utils/misc: Fix "epxeriencing" -> "experiencing" typo

### DIFF
--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -179,7 +179,7 @@ const printVersionInfo = context => {
             PACKAGE_VERSION
           )}) and "core" (${colors.green(
             requiredVersion
-          )}) versions are out of sync. This is probably fine, but if you're epxeriencing issues, update the ${colors.cyan(
+          )}) versions are out of sync. This is probably fine, but if you're experiencing issues, update the ${colors.cyan(
             PLATFORM_PACKAGE
           )} dependency in your ${colors.cyan(
             'package.json'


### PR DESCRIPTION
From a055940f (#282).