### PR TITLE
(improvement) Truncate source_zip in logs

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -87,8 +87,10 @@ const callAPI = (route, options, rawError = false) => {
       if (constants.DEBUG || global.argOpts.debug) {
         console.log(`>> ${requestOptions.method} ${requestOptions.url}`);
         if (requestOptions.body) {
+          const replacementStr = 'raw zip removed in logs';
           let cleanedBody = _.assign({}, JSON.parse(requestOptions.body), {
-            zip_file: 'raw zip removed in logs'
+            zip_file: replacementStr,
+            source_zip_file: replacementStr
           });
           console.log(`>> ${JSON.stringify(cleanedBody)}`);
         }


### PR DESCRIPTION
We already truncate `zip_file`, doing the same for `source_zip` so the logs aren't huge. 

Found it when cleaning the file here: https://gist.github.com/xavdid/34401189f4f56f0b4ce35df85bfd0fc4#file-6-1-0-txt-L1277