### PR TITLE
Include the right binary for deasync

### DIFF
--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -13,6 +13,7 @@ const updateNotifier = require('update-notifier');
 const colors = require('colors/safe');
 const ignore = require('ignore');
 const gitIgnore = require('parse-gitignore');
+const semver = require('semver');
 
 const eslint = require('eslint');
 
@@ -172,10 +173,12 @@ const forceIncludeDumbPath = (appConfig, filePath) => {
     return true; // Because of consistent-return
   });
 
+  const nodeMajorVersion = semver(constants.LAMBDA_VERSION).major;
+
   return (
     filePath.endsWith('package.json') ||
     filePath.endsWith('definition.json') ||
-    filePath.endsWith('/bin/linux-x64-node-8/deasync.node') || // Special, for zapier-platform-legacy-scripting-runner
+    filePath.endsWith(`/bin/linux-x64-node-${nodeMajorVersion}/deasync.node`) || // Special, for zapier-platform-legacy-scripting-runner
     filePath.match(
       path.sep === '\\' ? /aws-sdk\\apis\\.*\.json/ : /aws-sdk\/apis\/.*\.json/
     ) ||

--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -175,7 +175,7 @@ const forceIncludeDumbPath = (appConfig, filePath) => {
   return (
     filePath.endsWith('package.json') ||
     filePath.endsWith('definition.json') ||
-    filePath.endsWith('/bin/linux-x64-node-6/deasync.node') || // Special, for zapier-platform-legacy-scripting-runner
+    filePath.endsWith('/bin/linux-x64-node-8/deasync.node') || // Special, for zapier-platform-legacy-scripting-runner
     filePath.match(
       path.sep === '\\' ? /aws-sdk\\apis\\.*\.json/ : /aws-sdk\/apis\/.*\.json/
     ) ||


### PR DESCRIPTION
We run the apps on Node 8 in AWS Lambda since CLI 7.0.0, but we're still shipping the Node 6 binary for [deasync](https://github.com/abbr/deasync) (dependency of [legacy-scripting-runner](https://github.com/zapier/zapier-platform-legacy-scripting-runner)). This one-liner change should fix it.