### PR TITLE
Update docs to reflect support for async/await

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -1304,7 +1304,7 @@ Yes, though there are caveats. Your entire function only gets 30 seconds to run.
 [insert-file:./snippets/paging-poll.js]
 ```
 
-If you need to do more requests conditionally based on the results of an HTTP call (such as getting "next url" param, using `async/await` with a transpiler is the way to go. If you go this route, only page as far as you need to. Keep an eye on the polling [guidelines](https://zapier.com/developer/documentation/v2/deduplication/), namely the part about only iterating until you hit items that have probably been seen in a previous poll.
+If you need to do more requests conditionally based on the results of an HTTP call (such as the "next url" param or similar value), using `async/await` (as shown in the example below) is a good way to go. If you go this route, only page as far as you need to. Keep an eye on the polling [guidelines](https://zapier.com/developer/documentation/v2/deduplication/), namely the part about only iterating until you hit items that have probably been seen in a previous poll.
 
 ```js
 [insert-file:./snippets/async-polling.js]

--- a/README.md
+++ b/README.md
@@ -2255,7 +2255,7 @@ module.exports = {
 
 ```
 
-If you need to do more requests conditionally based on the results of an HTTP call (such as getting "next url" param, using `async/await` with a transpiler is the way to go. If you go this route, only page as far as you need to. Keep an eye on the polling [guidelines](https://zapier.com/developer/documentation/v2/deduplication/), namely the part about only iterating until you hit items that have probably been seen in a previous poll.
+If you need to do more requests conditionally based on the results of an HTTP call (such as the "next url" param or similar value), using `async/await` (as shown in the example below) is a good way to go. If you go this route, only page as far as you need to. Keep an eye on the polling [guidelines](https://zapier.com/developer/documentation/v2/deduplication/), namely the part about only iterating until you hit items that have probably been seen in a previous poll.
 
 ```js
 // a hypothetical API where payloads are big so we want to heavily limit how much comes back

--- a/docs/index.html
+++ b/docs/index.html
@@ -3993,7 +3993,7 @@ npm run zapier-push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>If you need to do more requests conditionally based on the results of an HTTP call (such as getting &quot;next url&quot; param, using <code>async/await</code> with a transpiler is the way to go. If you go this route, only page as far as you need to. Keep an eye on the polling <a href="https://zapier.com/developer/documentation/v2/deduplication/">guidelines</a>, namely the part about only iterating until you hit items that have probably been seen in a previous poll.</p>
+      <p>If you need to do more requests conditionally based on the results of an HTTP call (such as the &quot;next url&quot; param or similar value), using <code>async/await</code> (as shown in the example below) is a good way to go. If you go this route, only page as far as you need to. Keep an eye on the polling <a href="https://zapier.com/developer/documentation/v2/deduplication/">guidelines</a>, namely the part about only iterating until you hit items that have probably been seen in a previous poll.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// a hypothetical API where payloads are big so we want to heavily limit how much comes back</span>


### PR DESCRIPTION
This is a minor tweak to a section in our docs that states a transpiler is needed to use async/await. Async/await is supported out of the box since `zapier-platform-cli`/`core` v7.0.0 (when we switched to Node v8.10).