### PR TITLE
Fix after hook in smoke test

### DIFF
--- a/src/smoke-tests/smoke-tests.js
+++ b/src/smoke-tests/smoke-tests.js
@@ -88,8 +88,8 @@ describe('smoke tests - setup will take some time', () => {
   });
 
   after(() => {
-    fs.unlink(context.package.path);
-    fs.remove(context.workdir);
+    fs.unlinkSync(context.package.path);
+    fs.removeSync(context.workdir);
   });
 
   it('package size should not change much', async () => {


### PR DESCRIPTION
Fixes the cleanup hook in the smoke test, where we should be using sync `fs` operations.