### PR TITLE
[minor] add Dynamic Dropdown example app

### DIFF
--- a/src/app-templates.js
+++ b/src/app-templates.js
@@ -1,21 +1,30 @@
 // list of template (example) apps
 // https://github.com/zapier?utf8=%E2%9C%93&q=zapier-platform-example-app-&type=&language=
 module.exports = [
-  'babel',
-  'basic-auth',
+  // basic
+  'minimal',
+  'trigger',
+  'search',
   'create',
+
+  // auth types
+  'basic-auth',
   'custom-auth',
+  'oauth2',
+  'session-auth',
+
+  // features
   'dynamic-dropdown',
   'files',
-  'github',
   'middleware',
-  'minimal',
-  'oauth2',
   'resource',
   'rest-hooks',
-  'search',
   'search-or-create',
-  'session-auth',
-  'trigger',
-  'typescript'
+
+  // transpilers
+  'babel',
+  'typescript',
+
+  // full examples
+  'github'
 ];

--- a/src/app-templates.js
+++ b/src/app-templates.js
@@ -1,20 +1,21 @@
 // list of template (example) apps
-// https://github.com/zapier/zapier-platform-example-app-*
+// https://github.com/zapier?utf8=%E2%9C%93&q=zapier-platform-example-app-&type=&language=
 module.exports = [
-  'minimal',
-  'resource',
-  'trigger',
-  'create',
-  'search',
-  'middleware',
-  'basic-auth',
-  'custom-auth',
-  'oauth2',
-  'session-auth',
   'babel',
-  'rest-hooks',
+  'basic-auth',
+  'create',
+  'custom-auth',
+  'dynamic-dropdown',
   'files',
   'github',
+  'middleware',
+  'minimal',
+  'oauth2',
+  'resource',
+  'rest-hooks',
+  'search',
   'search-or-create',
+  'session-auth',
+  'trigger',
   'typescript'
 ];


### PR DESCRIPTION
I realized I had made a dynamic dropdown example but never added it into cli. it's now out of date, but will hopefully get brought up to speed when the next cli release goes out. 

I also updated the link to the actual 100% list of example apps (filters our github repos) and sorted the list of apps. If we wanted, we could arrange them in ascending order of complexity or grouped by type (simple, auth-based, transpiler, feature, etc) if we wanted. 