### PR TITLE
Adjust convert scaffold to handle test triggers that return arrays.

### DIFF
--- a/scaffold/convert/oauth2.template.js
+++ b/scaffold/convert/oauth2.template.js
@@ -1,4 +1,4 @@
-const { replaceVars, performAuthTest } = require('./utils');
+const { replaceVars, ensureObject } = require('./utils');
 const testTrigger = require('<%= TEST_TRIGGER_MODULE %>');
 <% if (hasPreOAuthTokenScripting && hasPostOAuthTokenScripting) { %>
 const getAccessToken = (z, bundle) => {
@@ -120,7 +120,7 @@ const getConnectionLabel = (z, bundle) => {
 const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: 'oauth2',
-  test: performAuthTest(testTrigger.operation.perform),
+  test: ensureObject(testTrigger.operation.perform),
   oauth2Config: {
     authorizeUrl: {
       method: 'GET',

--- a/scaffold/convert/oauth2.template.js
+++ b/scaffold/convert/oauth2.template.js
@@ -1,4 +1,4 @@
-const { replaceVars } = require('./utils');
+const { replaceVars, performAuthTest } = require('./utils');
 const testTrigger = require('<%= TEST_TRIGGER_MODULE %>');
 <% if (hasPreOAuthTokenScripting && hasPostOAuthTokenScripting) { %>
 const getAccessToken = (z, bundle) => {
@@ -120,7 +120,7 @@ const getConnectionLabel = (z, bundle) => {
 const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: 'oauth2',
-  test: testTrigger.operation.perform,
+  test: performAuthTest(testTrigger.operation.perform),
   oauth2Config: {
     authorizeUrl: {
       method: 'GET',

--- a/scaffold/convert/session.template.js
+++ b/scaffold/convert/session.template.js
@@ -40,7 +40,7 @@ const getConnectionLabel = (z, bundle) => {
 const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: 'session',
-  test: testTrigger.operation.perform,
+  test: performAuthTest(testTrigger.operation.perform),
   fields: [
 <%= FIELDS %>
   ],

--- a/scaffold/convert/session.template.js
+++ b/scaffold/convert/session.template.js
@@ -1,3 +1,4 @@
+const { ensureObject } = require('./utils');
 const testTrigger = require('<%= TEST_TRIGGER_MODULE %>');
 
 const getSessionKey = (z, bundle) => {
@@ -40,7 +41,7 @@ const getConnectionLabel = (z, bundle) => {
 const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: 'session',
-  test: performAuthTest(testTrigger.operation.perform),
+  test: ensureObject(testTrigger.operation.perform),
   fields: [
 <%= FIELDS %>
   ],

--- a/scaffold/convert/simple-auth.template.js
+++ b/scaffold/convert/simple-auth.template.js
@@ -1,3 +1,5 @@
+const { ensureObject } = require('./utils');
+
 <% if (TEST_TRIGGER_MODULE) { %>
 const testTrigger = require('<%= TEST_TRIGGER_MODULE %>');
 <% } %>
@@ -17,7 +19,7 @@ const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: '<%= TYPE %>',
 <% if (TEST_TRIGGER_MODULE) { %>
-  test: performAuthTest(testTrigger.operation.perform),
+  test: ensureObject(testTrigger.operation.perform),
 <% } %>
   fields: [
 <%= FIELDS %>

--- a/scaffold/convert/simple-auth.template.js
+++ b/scaffold/convert/simple-auth.template.js
@@ -17,7 +17,7 @@ const authentication = {
   // TODO: just an example stub - you'll need to complete
   type: '<%= TYPE %>',
 <% if (TEST_TRIGGER_MODULE) { %>
-  test: testTrigger.operation.perform,
+  test: performAuthTest(testTrigger.operation.perform),
 <% } %>
   fields: [
 <%= FIELDS %>

--- a/scaffold/convert/utils.template.js
+++ b/scaffold/convert/utils.template.js
@@ -33,17 +33,19 @@ const runBeforeMiddlewares = (request, z, bundle) => {
 // Wrap legacy auth test triggers to handle array responses.
 // Web builder test triggers can return arrays, which the CLI
 // does not handle. So, if an array is returned from the test
-// trigger, grab the first result and return that. 
-const performAuthTest = testTrigger =>
-  testTrigger.operation.perform(z, bundle).then(response => {
-    if (Array.isArray(response)) {
-      // if legacy test trigger returns an array, return the first element:
-      return response[0];
-    }
-    return response;
-  });
+// trigger, grab the first result and return that.
+const ensureObject = perform => {
+  return (z, bundle) =>
+    perform(z, bundle).then(response => {
+      if (Array.isArray(response) && response.length > 0) {
+        return response[0];
+      }
+      return response;
+    });
+};
 
 module.exports = {
   replaceVars,
-  runBeforeMiddlewares
+  runBeforeMiddlewares,
+  ensureObject
 };

--- a/scaffold/convert/utils.template.js
+++ b/scaffold/convert/utils.template.js
@@ -30,6 +30,19 @@ const runBeforeMiddlewares = (request, z, bundle) => {
   }, request);
 };
 
+// Wrap legacy auth test triggers to handle array responses.
+// Web builder test triggers can return arrays, which the CLI
+// does not handle. So, if an array is returned from the test
+// trigger, grab the first result and return that. 
+const performAuthTest = testTrigger =>
+  testTrigger.operation.perform(z, bundle).then(response => {
+    if (Array.isArray(response)) {
+      // if legacy test trigger returns an array, return the first element:
+      return response[0];
+    }
+    return response;
+  });
+
 module.exports = {
   replaceVars,
   runBeforeMiddlewares

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -30,10 +30,11 @@ const loadAuthModuleFromString = string => {
 
   // utils doesn't exist during testing neither, so let's mock it, too.
   string = string.replace(
-    /const { replaceVars, performAuthTest } = require\(.*;/,
+    /const { replaceVars, ensureObject } = require\(.*;/,
     ''
   );
-  string = 'const performAuthTest = func => func;\n' + string;
+  string = string.replace(/const { ensureObject } = require\(.*;/, '');
+  string = 'const ensureObject = func => func;\n' + string;
 
   return requireFromString(string);
 };

--- a/src/tests/utils/convert.js
+++ b/src/tests/utils/convert.js
@@ -29,7 +29,11 @@ const loadAuthModuleFromString = string => {
     string;
 
   // utils doesn't exist during testing neither, so let's mock it, too.
-  string = string.replace(/const { replaceVars } = require\(.*;/, '');
+  string = string.replace(
+    /const { replaceVars, performAuthTest } = require\(.*;/,
+    ''
+  );
+  string = 'const performAuthTest = func => func;\n' + string;
 
   return requireFromString(string);
 };


### PR DESCRIPTION
WIP - not fully tested yet!

Web builder auth test triggers can return arrays, which the CLI does not expect. So, shim it such that if the test trigger returns an array, return the first element of the array.