### PR TITLE
Show redirect_uri for OAuth1

### DIFF
--- a/src/commands/describe.js
+++ b/src/commands/describe.js
@@ -88,7 +88,10 @@ const describe = context => {
         authentication.paths = authenticationPaths
           .filter(path => _.has(definition, path))
           .join('\n');
-        if (authentication.type === 'oauth2') {
+        if (
+          authentication.type === 'oauth2' ||
+          authentication.type === 'oauth1'
+        ) {
           if (appConfig && version) {
             authentication.redirect_uri = version.oauth_redirect_uri;
           } else {


### PR DESCRIPTION
Makes sure `zapier describe` shows `redirect_uri` for OAuth1 apps.