### PR TITLE
Fix bug: `zapier push` doesn't stop on validation errors

### DIFF
--- a/src/utils/build.js
+++ b/src/utils/build.js
@@ -405,12 +405,17 @@ const build = async (zipPath, sourceZipPath, wdir) => {
 
   const validationErrors = validateResponse.results;
   if (validationErrors.length) {
-    return {
-      validationErrors: {
-        validation: validationErrors
-      }
-    };
+    if (global.argOpts.debug) {
+      console.log('\nErrors:');
+      console.log(validationErrors);
+      console.log('');
+    }
+
+    throw new Error(
+      'We hit some validation errors, try running `zapier validate` to see them!'
+    );
   }
+
   // No need to mention specifically we're validating style checks as that's
   //   implied from `zapier validate`, though it happens as a separate process
   const styleChecksResponse = await callAPI('/style-check', {


### PR DESCRIPTION
Fixes #387, a bug introduced to 7.6.0 by PR #382.

Steps to reproduce:

1. `zapier init example-app`
2. `zapier push` with some random name
3. create a trigger with a very short description (length < 12)
4. `zapier validate` would show an error
5. bump version to 1.0.1 in `package.json`
6. `zapier push` shows success, but 1.0.1 wasn't really pushed