### PR TITLE
update docs to use new meta

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -686,12 +686,12 @@ This object holds the user's auth details and the data for the API requests.
 | --- | --- | --- |
 | `isLoadingSample` | `false` | If true, this run was initiated manually via the Zap Editor |
 | `isFillingDynamicDropdown` | `false` | If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as `id` and `name`), though returning everything is fine too |
-| `isTestingAuth` | `false` | If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
 | `isPopulatingDedupe` | `false` | If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: [deduplication](#dedup) |
 | `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
 | `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
+| `isTestingAuth` | `false` | (legacy property) If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
 
-> Before version `8.0.0`, the information in `bundle.mta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
+> Before version `8.0.0`, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
 
 There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 

--- a/README-source.md
+++ b/README-source.md
@@ -684,14 +684,12 @@ This object holds the user's auth details and the data for the API requests.
 
 | key | default | description |
 | --- | --- | --- |
-| frontend | `false` | if true, this run was initiated manually via the Zap Editor |
-| prefill | `false` | if true, this poll is being used to populate a dynamic dropdown |
-| hydrate | `true`  | if true, the results of this run will be hydrated (false if we're in the middle of hydrating already) |
-| test_poll | `false` | if true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) on the auth |
-| standard_poll| `true`  | the opposite of `test_poll` |
-| first_poll | `false` | if true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. See: [deduplication](#dedup) |
-| limit | `-1` | the number of items to fetch. `-1` indicates there's no limit (which will almost always be the case) |
-| page | `0` | used in [paging](#paging) to uniquely identify which page of results should be returned |
+| `isLoadingSample` | `false` | If true, this run was initiated manually via the Zap Editor |
+| `isFillingDynamicDropdown` | `false` | If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as `id` and `name`), though returning everything is fine too |
+| `isTestingAuth` | `false` | If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
+| `isPopulatingDedupe` | `false` | If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: [deduplication](#dedup) |
+| `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
+| `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
 
 > `bundle.meta.zap.id` is only available in the `performSubscribe` and `performUnsubscribe` methods.
 

--- a/README-source.md
+++ b/README-source.md
@@ -680,7 +680,7 @@ This object holds the user's auth details and the data for the API requests.
 
 ### `bundle.meta`
 
-`bundle.meta` is extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:
+`bundle.meta` contains extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:
 
 | key | default | description |
 | --- | --- | --- |
@@ -691,7 +691,9 @@ This object holds the user's auth details and the data for the API requests.
 | `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
 | `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
 
-> `bundle.meta.zap.id` is only available in the `performSubscribe` and `performUnsubscribe` methods.
+> Before version `8.0.0`, the information in `bundle.mta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
+
+There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 
 The user's Zap ID is available during the [subscribe and unsubscribe](https://zapier.github.io/zapier-platform-schema/build/schema.html#basichookoperationschema) methods.
 

--- a/README.md
+++ b/README.md
@@ -1423,20 +1423,20 @@ This object holds the user's auth details and the data for the API requests.
 
 ### `bundle.meta`
 
-`bundle.meta` is extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:
+`bundle.meta` contains extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:
 
 | key | default | description |
 | --- | --- | --- |
-| frontend | `false` | if true, this run was initiated manually via the Zap Editor |
-| prefill | `false` | if true, this poll is being used to populate a dynamic dropdown |
-| hydrate | `true`  | if true, the results of this run will be hydrated (false if we're in the middle of hydrating already) |
-| test_poll | `false` | if true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) on the auth |
-| standard_poll| `true`  | the opposite of `test_poll` |
-| first_poll | `false` | if true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. See: [deduplication](#dedup) |
-| limit | `-1` | the number of items to fetch. `-1` indicates there's no limit (which will almost always be the case) |
-| page | `0` | used in [paging](#paging) to uniquely identify which page of results should be returned |
+| `isLoadingSample` | `false` | If true, this run was initiated manually via the Zap Editor |
+| `isFillingDynamicDropdown` | `false` | If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as `id` and `name`), though returning everything is fine too |
+| `isTestingAuth` | `false` | If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
+| `isPopulatingDedupe` | `false` | If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: [deduplication](#dedup) |
+| `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
+| `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
 
-> `bundle.meta.zap.id` is only available in the `performSubscribe` and `performUnsubscribe` methods.
+> Before version `8.0.0`, the information in `bundle.mta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
+
+There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 
 The user's Zap ID is available during the [subscribe and unsubscribe](https://zapier.github.io/zapier-platform-schema/build/schema.html#basichookoperationschema) methods.
 

--- a/README.md
+++ b/README.md
@@ -1429,12 +1429,12 @@ This object holds the user's auth details and the data for the API requests.
 | --- | --- | --- |
 | `isLoadingSample` | `false` | If true, this run was initiated manually via the Zap Editor |
 | `isFillingDynamicDropdown` | `false` | If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as `id` and `name`), though returning everything is fine too |
-| `isTestingAuth` | `false` | If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
 | `isPopulatingDedupe` | `false` | If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: [deduplication](#dedup) |
 | `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
 | `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
+| `isTestingAuth` | `false` | (legacy property) If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
 
-> Before version `8.0.0`, the information in `bundle.mta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
+> Before version `8.0.0`, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) for a mapping of old values to new.
 
 There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2618,7 +2618,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><code>bundle.meta</code> is extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:</p>
+      <p><code>bundle.meta</code> contains extra information useful for doing advanced behaviors depending on what the user is doing. It has the following options:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -2637,44 +2637,34 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </thead>
 <tbody>
 <tr>
-<td>frontend</td>
+<td><code>isLoadingSample</code></td>
 <td><code>false</code></td>
-<td>if true, this run was initiated manually via the Zap Editor</td>
+<td>If true, this run was initiated manually via the Zap Editor</td>
 </tr>
 <tr>
-<td>prefill</td>
+<td><code>isFillingDynamicDropdown</code></td>
 <td><code>false</code></td>
-<td>if true, this poll is being used to populate a dynamic dropdown</td>
+<td>If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as <code>id</code> and <code>name</code>), though returning everything is fine too</td>
 </tr>
 <tr>
-<td>hydrate</td>
-<td><code>true</code></td>
-<td>if true, the results of this run will be hydrated (false if we&apos;re in the middle of hydrating already)</td>
-</tr>
-<tr>
-<td>test_poll</td>
+<td><code>isTestingAuth</code></td>
 <td><code>false</code></td>
-<td>if true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> on the auth</td>
+<td>If true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> or during setup). We use this data to populate the auth label, but it&apos;s mostly used to verify we made a successful authenticated request</td>
 </tr>
 <tr>
-<td>standard_poll</td>
-<td><code>true</code></td>
-<td>the opposite of <code>test_poll</code></td>
-</tr>
-<tr>
-<td>first_poll</td>
+<td><code>isPopulatingDedupe</code></td>
 <td><code>false</code></td>
-<td>if true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. See: <a href="#dedup">deduplication</a></td>
+<td>If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: <a href="#dedup">deduplication</a></td>
 </tr>
 <tr>
-<td>limit</td>
+<td><code>limit</code></td>
 <td><code>-1</code></td>
-<td>the number of items to fetch. <code>-1</code> indicates there&apos;s no limit (which will almost always be the case)</td>
+<td>The number of items you should fetch. <code>-1</code> indicates there&apos;s no limit. Build this into your calls insofar as you are able</td>
 </tr>
 <tr>
-<td>page</td>
+<td><code>page</code></td>
 <td><code>0</code></td>
-<td>used in <a href="#paging">paging</a> to uniquely identify which page of results should be returned</td>
+<td>Used in <a href="#paging">paging</a> to uniquely identify which page of results should be returned</td>
 </tr>
 </tbody>
 </table>
@@ -2687,8 +2677,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>bundle.meta.zap.id</code> is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p>
-</blockquote><p>The user&apos;s Zap ID is available during the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
+<p>Before version <code>8.0.0</code>, the information in <code>bundle.mta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> the previous values and <a href="https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
+</blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2647,11 +2647,6 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 <td>If true, this poll is being used to populate a dynamic dropdown. You only need to return the fields you specified (such as <code>id</code> and <code>name</code>), though returning everything is fine too</td>
 </tr>
 <tr>
-<td><code>isTestingAuth</code></td>
-<td><code>false</code></td>
-<td>If true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> or during setup). We use this data to populate the auth label, but it&apos;s mostly used to verify we made a successful authenticated request</td>
-</tr>
-<tr>
 <td><code>isPopulatingDedupe</code></td>
 <td><code>false</code></td>
 <td>If true, the results of this poll will be used to initialize the deduplication list rather than trigger a zap. You should grab as many items as possible. See also: <a href="#dedup">deduplication</a></td>
@@ -2666,6 +2661,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 <td><code>0</code></td>
 <td>Used in <a href="#paging">paging</a> to uniquely identify which page of results should be returned</td>
 </tr>
+<tr>
+<td><code>isTestingAuth</code></td>
+<td><code>false</code></td>
+<td>(legacy property) If true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> or during setup). We use this data to populate the auth label, but it&apos;s mostly used to verify we made a successful authenticated request</td>
+</tr>
 </tbody>
 </table>
     </div>
@@ -2677,7 +2677,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Before version <code>8.0.0</code>, the information in <code>bundle.mta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> the previous values and <a href="https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
+<p>Before version <code>8.0.0</code>, the information in <code>bundle.meta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> for the previous values and <a href="https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
 </blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">


### PR DESCRIPTION
Updates the docs to reflect the new `bundle.meta` keys. This won't be relevant until `8.0.0`, so we should be sure to merge this before that goes out

I also tried to specify when each key would be useful. I think that still needs a little tweaking, but this is the idea.

Could also add a link to the [wiki page](https://github.com/zapier/zapier-platform-cli/wiki/bundle.meta-changes) I made for migrations (that we should include in the release notes)