### PR TITLE
respect 2fa settings

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -6,6 +6,7 @@ const utils = require('../utils');
 const QUESTION_USERNAME =
   'What is your Zapier login email address? (Ctrl-C to cancel)';
 const QUESTION_PASSWORD = 'What is your Zapier login password?';
+const QUESTION_TOTP = 'What is your current 6-digit 2FA code?';
 
 const login = async (context, firstTime = true) => {
   const checks = [
@@ -46,7 +47,19 @@ const login = async (context, firstTime = true) => {
   const username = await utils.getInput(QUESTION_USERNAME);
   const password = await utils.getInput(QUESTION_PASSWORD, { secret: true });
 
-  const deployKey = (await utils.createCredentials(username, password)).key;
+  let goodResponse;
+  try {
+    goodResponse = await utils.createCredentials(username, password);
+  } catch ({ errText, json: { errors } }) {
+    if (errors[0].startsWith('missing totp_code')) {
+      const code = await utils.getInput(QUESTION_TOTP);
+      goodResponse = await utils.createCredentials(username, password, code);
+    } else {
+      throw new Error(errText);
+    }
+  }
+
+  const { key: deployKey } = goodResponse;
 
   await utils.writeFile(
     constants.AUTH_LOCATION,

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -59,7 +59,7 @@ const login = async (context, firstTime = true) => {
     }
   }
 
-  const { key: deployKey } = goodResponse;
+  const deployKey = goodResponse.key;
 
   await utils.writeFile(
     constants.AUTH_LOCATION,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -118,16 +118,21 @@ const callAPI = (route, options, rawError = false) => {
 };
 
 // Given a valid username and password - create a new deploy key.
-const createCredentials = (username, password) => {
-  // TODO: 2fa in the future?
-  return callAPI('/keys', {
-    skipDeployKey: true,
-    method: 'POST',
-    body: {
-      username,
-      password
-    }
-  });
+const createCredentials = (username, password, totpCode) => {
+  return callAPI(
+    '/keys',
+    {
+      skipDeployKey: true,
+      method: 'POST',
+      body: {
+        username,
+        password,
+        totp_code: totpCode
+      }
+    },
+    // if totp is empty, we want a raw request so we can supress an error. If it's here, we want it to be "non-raw"
+    !totpCode
+  );
 };
 
 // Reads the JSON file in the app directory.


### PR DESCRIPTION
Now forces users that have 2FA enabled to supply a 2FA code to get a valid token. This corresponds to an unversioned server change (https://github.com/zapier/zapier/pull/23125) and will affect all CLI users on all versions, so we have to think about 4 use cases:

* new CLI user w/ 2fa - catches the initial error, supplies the 2FA code, is all set
* new CLI user w/o 2fa - doesn't see the 2FA error, logs in as normal
* User with old version of CLI w/ 2FA - won't be able to successfully login. Existing keys will continue to work, but they'll need the newer version of CLI (presumably `8.0.0`) to get access to their data. This shouldn't be a big impact, as most users who have the CLI already don't ever need to log in after the initial setup. This class of users is really only impacted if they installed a version, didn't log in, and then try to log in after the server PR is merged
* user w/ old version of CLI w/o 2FA - no problem, log in like normal

To help the users in group 3 above, the server error message specifically mentions updating CLI (and includes the command to do so). The only folks seeing that message are those with old versions, as this PR eats that message and prompts for the CLI code.

A potential UX improvement we could include is prompting for 2FA a second time in the case of a failed token (instead of making the user re-type email/pw just for missing the 30 sec window). It makes the `try/catch` logic a little deeper, but it's manageable if we think that'll be a common thing.