### PR TITLE
Add a better error message when uploading with a zip

### DIFF
--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -1,15 +1,20 @@
+const colors = require('colors/safe');
 const constants = require('../constants');
 const utils = require('../utils');
 
-const upload = context => {
-  context.line('Preparing to upload a new version.\n');
-  return utils.upload().then(() => {
+const upload = async context => {
+  try {
+    context.line('Preparing to upload a new version.\n');
+    await utils.upload();
+
     context.line(
       `\nUpload of ${constants.BUILD_PATH} and ${
         constants.SOURCE_PATH
       } complete! Try \`zapier versions\` now!`
     );
-  });
+  } catch (error) {
+    context.line(`${colors.red('Problem uploading:')} ${error.message}`);
+  }
 };
 upload.argsSpec = [];
 upload.argOptsSpec = {};

--- a/src/entry.js
+++ b/src/entry.js
@@ -123,7 +123,7 @@ module.exports = argv => {
     process.exit(1);
   }
 
-  commandFunc.apply(commands, [context].concat(args)).catch(err => {
+  commandFunc(context, ...args).catch(err => {
     utils.endSpinner(false);
 
     if (DEBUG || global.argOpts.debug) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -270,6 +270,13 @@ const upload = (zipPath, sourceZipPath, appDir) => {
 
   const fullZipPath = path.resolve(appDir, zipPath);
   const fullSourceZipPath = path.resolve(appDir, sourceZipPath);
+  const isMissingZip = !fs.existsSync(fullZipPath);
+
+  if (isMissingZip) {
+    throw new Error(
+      'Missing a built app. Try running `zapier build` first.\nOr you could run `zapier push`, which will build and upload in one command.'
+    );
+  }
 
   return getLinkedApp(appDir)
     .then(app => {


### PR DESCRIPTION
## Description
When a dev attempts to `zapier upload` without having built the integration, we silently fail when trying to read the zip. 

Instead, we'll check to see if the zip exists, and then suggest running `zapier push` if we still need to build.

## Issue
#351 