### PR TITLE
Update readme details for version number

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -212,7 +212,7 @@ If you'd like to manage your **App**, use these commands:
 
 ## Deploying an App Version
 
-An App Version is related to a specific App but is an "immutable" implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. By default, **every App Version is private** but you can `zapier promote` it to production for use by over 1 million Zapier users.
+An App Version is related to a specific App but is an "immutable" implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. The App Version is pulled from the version within the `package.json`. To create a new App Version, update the version number in that file. By default, **every App Version is private** but you can `zapier promote` it to production for use by over 1 million Zapier users.
 
 ```bash
 # push your app version to Zapier

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ If you'd like to manage your **App**, use these commands:
 
 ## Deploying an App Version
 
-An App Version is related to a specific App but is an "immutable" implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. By default, **every App Version is private** but you can `zapier promote` it to production for use by over 1 million Zapier users.
+An App Version is related to a specific App but is an "immutable" implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. The App Version is pulled from the version within the `package.json`. To create a new App Version, update the version number in that file. By default, **every App Version is private** but you can `zapier promote` it to production for use by over 1 million Zapier users.
 
 ```bash
 # push your app version to Zapier

--- a/docs/index.html
+++ b/docs/index.html
@@ -984,7 +984,7 @@ zapier apps
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>An App Version is related to a specific App but is an &quot;immutable&quot; implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. By default, <strong>every App Version is private</strong> but you can <code>zapier promote</code> it to production for use by over 1 million Zapier users.</p>
+      <p>An App Version is related to a specific App but is an &quot;immutable&quot; implementation of your app. This makes it easy to run multiple versions for multiple users concurrently. The App Version is pulled from the version within the <code>package.json</code>. To create a new App Version, update the version number in that file. By default, <strong>every App Version is private</strong> but you can <code>zapier promote</code> it to production for use by over 1 million Zapier users.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># push your app version to Zapier</span>


### PR DESCRIPTION
A partner pointed out that there wasn't anything explicit in our documentation to indicate how version numbers are set and can be updated. This PR adds a couple of lines to make that clear.