### PR TITLE
Add example for input fields with 'children' parameter

### DIFF
--- a/README-source.md
+++ b/README-source.md
@@ -579,6 +579,14 @@ Computed fields work like any other field, though with `computed: true` property
 
 You can see examples of computed fields in the [OAuth2](#oauth2) or [Session Auth](#session) example sections.
 
+### Nested & Children (Line Item) Fields
+
+When your action needs to accept an array of items, you can include an input field with the `children` attribute. The `children` attribute accepts a list of [fields](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) that can be input for each item in this array.  
+
+```js
+[insert-file:./snippets/input-fields-children.js]
+```
+
 ## Output Fields
 
 On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the `outputFields`. Output Fields are what your users would see when they select a field provided by your trigger, search or create to map it to another.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
   * [Dynamic Dropdowns](#dynamic-dropdowns)
   * [Search-Powered Fields](#search-powered-fields)
   * [Computed Fields](#computed-fields)
-- [Output Fields](#output-fields)
   * [Nested & Children (Line Item) Fields](#nested--children-line-item-fields)
+- [Output Fields](#output-fields)
+  * [Nested & Children (Line Item) Fields](#nested--children-line-item-fields-1)
 - [Z Object](#z-object)
   * [`z.request([url], options)`](#zrequesturl-options)
   * [`z.console`](#zconsole)
@@ -1242,6 +1243,39 @@ Zapier stores every value from an integration's test API call in `bundle.authDat
 Computed fields work like any other field, though with `computed: true` property, and `required: false` as user can not enter computed fields themselves. Reference computed fields in API calls as `{{bundle.authData.field}}`, replacing `field` with that field's name from your test API call response.
 
 You can see examples of computed fields in the [OAuth2](#oauth2) or [Session Auth](#session) example sections.
+
+### Nested & Children (Line Item) Fields
+
+When your action needs to accept an array of items, you can include an input field with the `children` attribute. The `children` attribute accepts a list of [fields](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) that can be input for each item in this array.  
+
+```js
+[
+  {
+    key: 'lineItems',
+    required: true,
+    children: [
+      {
+        key: 'lineItemId',
+        type: 'integer',
+        label: 'Line Item ID',
+        required: true
+      },
+      {
+        key: 'name',
+        type: 'string',
+        label: 'Name',
+        required: true
+      },
+      {
+        key: 'description',
+        type: 'string',
+        label: 'Description'
+      }
+    ]
+  }
+];
+
+```
 
 ## Output Fields
 

--- a/README.md
+++ b/README.md
@@ -1249,31 +1249,39 @@ You can see examples of computed fields in the [OAuth2](#oauth2) or [Session Aut
 When your action needs to accept an array of items, you can include an input field with the `children` attribute. The `children` attribute accepts a list of [fields](https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema) that can be input for each item in this array.  
 
 ```js
-[
-  {
-    key: 'lineItems',
-    required: true,
-    children: [
+const App = {
+  //...
+  operation: {
+    //...
+    inputFields: [
       {
-        key: 'lineItemId',
-        type: 'integer',
-        label: 'Line Item ID',
-        required: true
-      },
-      {
-        key: 'name',
-        type: 'string',
-        label: 'Name',
-        required: true
-      },
-      {
-        key: 'description',
-        type: 'string',
-        label: 'Description'
+      key: 'lineItems',
+      required: true,
+      children: [
+          {
+          key: 'lineItemId',
+          type: 'integer',
+          label: 'Line Item ID',
+          required: true
+          },
+          {
+          key: 'name',
+          type: 'string',
+          label: 'Name',
+          required: true
+          },
+          {
+          key: 'description',
+          type: 'string',
+          label: 'Description'
+          }
+        ]
       }
-    ]
+    ],
+    // ...
   }
-];
+}
+;
 
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2223,31 +2223,39 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <p>When your action needs to accept an array of items, you can include an input field with the <code>children</code> attribute. The <code>children</code> attribute accepts a list of <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema">fields</a> that can be input for each item in this array.  </p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">[
-  {
-    <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItems&apos;</span>,
-    <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
-    <span class="hljs-attr">children</span>: [
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {
+  <span class="hljs-comment">//...</span>
+  operation: {
+    <span class="hljs-comment">//...</span>
+    inputFields: [
       {
-        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItemId&apos;</span>,
-        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
-        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Line Item ID&apos;</span>,
-        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
-      },
-      {
-        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;name&apos;</span>,
-        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
-        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Name&apos;</span>,
-        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
-      },
-      {
-        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;description&apos;</span>,
-        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
-        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Description&apos;</span>
+      <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItems&apos;</span>,
+      <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
+      <span class="hljs-attr">children</span>: [
+          {
+          <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItemId&apos;</span>,
+          <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
+          <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Line Item ID&apos;</span>,
+          <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
+          },
+          {
+          <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;name&apos;</span>,
+          <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
+          <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Name&apos;</span>,
+          <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
+          },
+          {
+          <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;description&apos;</span>,
+          <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
+          <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Description&apos;</span>
+          }
+        ]
       }
-    ]
+    ],
+    <span class="hljs-comment">// ...</span>
   }
-];
+}
+;
 
 </code></pre>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -287,10 +287,11 @@ a code {
 <li><a href="#dynamic-dropdowns">Dynamic Dropdowns</a></li>
 <li><a href="#search-powered-fields">Search-Powered Fields</a></li>
 <li><a href="#computed-fields">Computed Fields</a></li>
+<li><a href="#nested--children-line-item-fields">Nested &amp; Children (Line Item) Fields</a></li>
 </ul>
 </li>
 <li><a href="#output-fields">Output Fields</a><ul>
-<li><a href="#nested--children-line-item-fields">Nested &amp; Children (Line Item) Fields</a></li>
+<li><a href="#nested--children-line-item-fields-1">Nested &amp; Children (Line Item) Fields</a></li>
 </ul>
 </li>
 <li><a href="#z-object">Z Object</a><ul>
@@ -483,10 +484,11 @@ a code {
 <li><a href="#dynamic-dropdowns">Dynamic Dropdowns</a></li>
 <li><a href="#search-powered-fields">Search-Powered Fields</a></li>
 <li><a href="#computed-fields">Computed Fields</a></li>
+<li><a href="#nested--children-line-item-fields">Nested &amp; Children (Line Item) Fields</a></li>
 </ul>
 </li>
 <li><a href="#output-fields">Output Fields</a><ul>
-<li><a href="#nested--children-line-item-fields">Nested &amp; Children (Line Item) Fields</a></li>
+<li><a href="#nested--children-line-item-fields-1">Nested &amp; Children (Line Item) Fields</a></li>
 </ul>
 </li>
 <li><a href="#z-object">Z Object</a><ul>
@@ -2204,6 +2206,50 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="nested--children-line-item-fields">Nested &amp; Children (Line Item) Fields</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>When your action needs to accept an array of items, you can include an input field with the <code>children</code> attribute. The <code>children</code> attribute accepts a list of <a href="https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema">fields</a> that can be input for each item in this array.  </p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">[
+  {
+    <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItems&apos;</span>,
+    <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
+    <span class="hljs-attr">children</span>: [
+      {
+        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItemId&apos;</span>,
+        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
+        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Line Item ID&apos;</span>,
+        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
+      },
+      {
+        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;name&apos;</span>,
+        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
+        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Name&apos;</span>,
+        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>
+      },
+      {
+        <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;description&apos;</span>,
+        <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
+        <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Description&apos;</span>
+      }
+    ]
+  }
+];
+
+</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/snippets/input-fields-children.js
+++ b/snippets/input-fields-children.js
@@ -1,0 +1,25 @@
+[
+  {
+    key: 'lineItems',
+    required: true,
+    children: [
+      {
+        key: 'lineItemId',
+        type: 'integer',
+        label: 'Line Item ID',
+        required: true
+      },
+      {
+        key: 'name',
+        type: 'string',
+        label: 'Name',
+        required: true
+      },
+      {
+        key: 'description',
+        type: 'string',
+        label: 'Description'
+      }
+    ]
+  }
+];

--- a/snippets/input-fields-children.js
+++ b/snippets/input-fields-children.js
@@ -1,25 +1,32 @@
-[
-  {
-    key: 'lineItems',
-    required: true,
-    children: [
+const App = {
+  //...
+  operation: {
+    //...
+    inputFields: [
       {
-        key: 'lineItemId',
-        type: 'integer',
-        label: 'Line Item ID',
-        required: true
-      },
-      {
-        key: 'name',
-        type: 'string',
-        label: 'Name',
-        required: true
-      },
-      {
-        key: 'description',
-        type: 'string',
-        label: 'Description'
+        key: 'lineItems',
+        required: true,
+        children: [
+          {
+            key: 'lineItemId',
+            type: 'integer',
+            label: 'Line Item ID',
+            required: true
+          },
+          {
+            key: 'name',
+            type: 'string',
+            label: 'Name',
+            required: true
+          },
+          {
+            key: 'description',
+            type: 'string',
+            label: 'Description'
+          }
+        ]
       }
     ]
+    // ...
   }
-];
+};


### PR DESCRIPTION
A developer/partner couldn't find any examples of how to specify line items for an action. Adding a brief description and example in this PR.