### PR TITLE
logout by only killing one key, not all

### DIFF
--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -3,13 +3,14 @@ const utils = require('../utils');
 
 const logout = async context => {
   context.line(
-    'Preparing to deactivate personal deploy keys and reset local configs.'
+    'Preparing to deactivate local deploy key and reset local configs.'
   );
   context.line();
-  utils.startSpinner('Deactivating personal deploy keys');
+  utils.startSpinner('Deactivating local deploy key');
   try {
     await utils.callAPI('/keys', {
-      method: 'DELETE'
+      method: 'DELETE',
+      body: { single: true }
     });
   } catch (e) {
     // no worries
@@ -21,18 +22,16 @@ const logout = async context => {
 
   utils.endSpinner();
   context.line();
-  context.line(
-    'All personal deploy keys deactivated - now try `zapier login` to login again.'
-  );
+  context.line('The active deploy key was deactivated');
 };
 logout.argsSpec = [];
 logout.argOptsSpec = {};
-logout.help = `Deactivates all your personal deploy keys and resets \`${
+logout.help = `Deactivates your acive deploy key and resets \`${
   constants.AUTH_LOCATION_RAW
 }\`.`;
 logout.example = 'zapier logout';
 logout.docs = `
-Deactivates all your personal deploy keys and resets your local config. Does not delete any apps or versions.
+Deactivates your local deploy key and resets your local config. Does not delete any apps, versions, or other keys. To audit all your active deploy keys, go to TODO: FIX.
 
 > This will delete the  \`${
   constants.AUTH_LOCATION_RAW
@@ -40,12 +39,12 @@ Deactivates all your personal deploy keys and resets your local config. Does not
 
 ${'```'}bash
 $ zapier logout
-Preparing to deactivate personal deploy keys and reset local configs.
+Preparing to deactivate local deploy key and reset local configs.
 
-  Deactivating personal deploy keys - done!
+  Deactivating local deploy key - done!
   Destroying \`~/.zapierrc\` - done!
 
-All personal keys deactivated - now try \`zapier login\` to login again.
+The active deploy key was deactivated
 ${'```'}
 `;
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -85,13 +85,18 @@ const callAPI = (route, options, rawError = false) => {
       }
 
       if (constants.DEBUG || global.argOpts.debug) {
-        console.log(`>> ${requestOptions.method} ${requestOptions.url}`);
+        console.log(`\n>> ${requestOptions.method} ${requestOptions.url}`);
         if (requestOptions.body) {
           const replacementStr = 'raw zip removed in logs';
-          let cleanedBody = _.assign({}, JSON.parse(requestOptions.body), {
-            zip_file: replacementStr,
-            source_zip_file: replacementStr
-          });
+          const requestBody = JSON.parse(requestOptions.body);
+          const cleanedBody = {};
+          for (const k in requestBody) {
+            if (k.includes('zip_file')) {
+              cleanedBody[k] = replacementStr;
+            } else {
+              cleanedBody[k] = requestBody[k];
+            }
+          }
           console.log(`>> ${JSON.stringify(cleanedBody)}`);
         }
         console.log(`<< ${res.status}`);

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -80,7 +80,9 @@ const isValidNodeVersion = () => {
 };
 
 const isValidAppInstall = command => {
-  if (['help', 'init', 'login', 'apps', 'convert'].includes(command)) {
+  if (
+    ['help', 'init', 'login', 'apps', 'convert', 'logout'].includes(command)
+  ) {
     return { valid: true };
   }
 


### PR DESCRIPTION
By default, `zapier logout` deactivated all keys. That's odd behavior, so we're doing to make it only kill the active key. This relies on some server work that's not done yet, so there's not much to see yet. Also did some unrelated logging improvements. 